### PR TITLE
process non-direct referenced webcontent files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as Convert from './convert';
 import * as Media from './media';
 import { processResources } from './process';
 import { upload } from './utils/upload';
+import { addWebContentToMediaSummary } from './resources/webcontent';
 const fs = require('fs');
 
 const optionDefinitions = [
@@ -171,10 +172,11 @@ function convertAction() {
 
         const updated = Convert.updateDerivativeReferences(converted);
         const withTagsInsteadOfPools = Convert.generatePoolTags(updated);
-        const mediaItems = Object.keys(mediaSummary.mediaItems).map((k: string) => mediaSummary.mediaItems[k]);
-
-        Convert.output(
-          projectSlug, packageDirectory, outputDirectory, hierarchy, withTagsInsteadOfPools, mediaItems);
+        addWebContentToMediaSummary(packageDirectory, mediaSummary).then((results) => {
+          const mediaItems = Object.keys(mediaSummary.mediaItems).map((k: string) => results.mediaItems[k]);
+          Convert.output(
+            projectSlug, packageDirectory, outputDirectory, hierarchy, withTagsInsteadOfPools, mediaItems);
+        });
       });
 
     });

--- a/src/resources/webcontent.ts
+++ b/src/resources/webcontent.ts
@@ -19,7 +19,6 @@ export function addWebContentToMediaSummary(directory: string, summary: MediaSum
         const absolutePath = path.resolve(file);
         const name = getName(absolutePath);
         if (summary.mediaItems[absolutePath] === undefined) {
-          console.log(absolutePath);
           const flattenedName = (summary.flattenedNames[name])
             ? generateNewName(name, summary.flattenedNames)
             : name;

--- a/src/resources/webcontent.ts
+++ b/src/resources/webcontent.ts
@@ -8,8 +8,7 @@ const md5File = require('md5-file');
 
 export function addWebContentToMediaSummary(directory: string, summary: MediaSummary)
   : Promise<MediaSummary> {
-  const getName = (file: string) => file.substr(file.lastIndexOf('/') + 1);
-  const getWebcontentName = (file: string) => file.substr(file.lastIndexOf('webcontent'));
+  const getName = (file: string) => file.substr(file.lastIndexOf('webcontent'));
   const toURL = (name: string) => `${summary.urlPrefix}/${summary.projectSlug}/${name}`;
 
   return new Promise((resolve, reject) => {
@@ -19,7 +18,6 @@ export function addWebContentToMediaSummary(directory: string, summary: MediaSum
 
         const absolutePath = path.resolve(file);
         const name = getName(absolutePath);
-        const webContentName = getWebcontentName(file);
         if (summary.mediaItems[absolutePath] === undefined) {
           console.log(absolutePath);
           const flattenedName = (summary.flattenedNames[name])
@@ -33,7 +31,7 @@ export function addWebContentToMediaSummary(directory: string, summary: MediaSum
             md5: md5File.sync(absolutePath),
             mimeType: mime.lookup(absolutePath) || 'application/octet-stream',
             references: [],
-            url: toURL(webContentName),
+            url: toURL(name),
           };
         }
       });

--- a/src/resources/webcontent.ts
+++ b/src/resources/webcontent.ts
@@ -1,0 +1,69 @@
+import { MediaSummary } from 'media';
+
+const glob = require('glob');
+const fs = require('fs');
+const path = require('path');
+const mime = require('mime-types');
+const md5File = require('md5-file');
+
+export function addWebContentToMediaSummary(directory: string, summary: MediaSummary)
+  : Promise<MediaSummary> {
+  const getName = (file: string) => file.substr(file.lastIndexOf('/') + 1);
+  const getWebcontentName = (file: string) => file.substr(file.lastIndexOf('webcontent'));
+  const toURL = (name: string) => `${summary.urlPrefix}/${summary.projectSlug}/${name}`;
+
+  return new Promise((resolve, reject) => {
+    glob(`${directory}/**/webcontent/**/*.*`, {}, (err: any, files: any) => {
+
+      files.forEach((file: string) => {
+
+        const absolutePath = path.resolve(file);
+        const name = getName(absolutePath);
+        const webContentName = getWebcontentName(file);
+        if (summary.mediaItems[absolutePath] === undefined) {
+          console.log(absolutePath);
+          const flattenedName = (summary.flattenedNames[name])
+            ? generateNewName(name, summary.flattenedNames)
+            : name;
+
+          summary.mediaItems[absolutePath] = {
+            file: absolutePath,
+            fileSize: getFilesizeInBytes(absolutePath),
+            flattenedName,
+            md5: md5File.sync(absolutePath),
+            mimeType: mime.lookup(absolutePath) || 'application/octet-stream',
+            references: [],
+            url: toURL(webContentName),
+          };
+        }
+      });
+      resolve(summary);
+    });
+  });
+}
+
+function getFilesizeInBytes(filename: string) {
+  const stats = fs.statSync(filename);
+  const fileSizeInBytes = stats.size;
+  return fileSizeInBytes;
+}
+
+function generateNewName(name: string, flattenedNames: { [k: string]: string }) {
+
+  const buildCandidateName = (name.indexOf('.') >= 0)
+    ? (n: string, i: number): string => {
+      const parts = n.split('.');
+      return `${parts[0]}_${i}.${parts[1]}`;
+    }
+    : (n: string, i: number): string => `${name}_${i}`;
+
+  let i = 1;
+  while (true) {
+    const candidateName = buildCandidateName(name, i);
+    if (flattenedNames[candidateName] === undefined) {
+      return candidateName;
+    }
+    i++;
+  }
+
+}

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -9,9 +9,8 @@ function flattenSection($: any, selector: string, tag: string) {
 
   triple.each((i: any, elem: any) => {
     const text = $(elem).children('title').html();
-    const body = $(elem).children('body').html();
 
-    $(elem).children('title').replaceWith(`<${tag}>${text}</${tag}>${body}`);
+    $(elem).children('title').replaceWith(`<${tag}>${text}</${tag}>`);
     $(elem).children('body').replaceWith($(elem).children('body').children());
     $(elem).replaceWith($(elem).children());
   });


### PR DESCRIPTION
Some of the supporting webcontent files have non-standard references with activities, especially custom activities. Those are currently being ignored by the course-digest. The PR resolves this by appending all other webcontent files to the media-manifest.json