### PR TITLE
[FEATURE] Preserve supporting content in formative assessments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,10 +177,11 @@ function convertAction() {
 
         const updated = Convert.updateDerivativeReferences(converted);
         const withTagsInsteadOfPools = Convert.generatePoolTags(updated);
+        const withoutTemporary = withTagsInsteadOfPools.filter(u => u.type !== 'TemporaryContent')
         const mediaItems = Object.keys(mediaSummary.mediaItems).map((k: string) => mediaSummary.mediaItems[k]);
 
         Convert.output(
-          projectSlug, packageDirectory, outputDirectory, hierarchy, withTagsInsteadOfPools, mediaItems);
+          projectSlug, packageDirectory, outputDirectory, hierarchy, withoutTemporary, mediaItems);
       });
 
     });

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -1,7 +1,7 @@
 import { visit } from '../utils/xml';
 import * as Histogram from '../utils/histogram';
 import { guid, ItemReference, replaceAll } from '../utils/common';
-import { Resource, TorusResource, Summary, Activity } from './resource';
+import { Resource, TorusResource, Summary, Activity, TemporaryContent } from './resource';
 import { standardContentManipulations, processCodeblock } from './common';
 import { cata } from './questions/cata';
 import { buildMulti } from './questions/multi';
@@ -405,6 +405,18 @@ export function processAssessmentModel(legacyId: string, children: any) {
         content.page = pageId;
       }
 
+      items.push({
+        type: 'TemporaryContent',
+        id: content.id,
+        originalFile: '',
+        title: '',
+        tags: [],
+        unresolvedReferences: [],
+        content,
+        objectives: [],
+        legacyId,
+      } as TemporaryContent);
+    
       return content;
 
     }

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -11,7 +11,8 @@ export interface Summary {
 }
 
 export type ResourceType = 'WorkbookPage' | 'Organization' | 'Objectives' | 'Pool'
-| 'Formative' | 'Summative' | 'Feedback' | 'Superactivity' | 'Skills' | 'Other';
+| 'Formative' | 'Summative' | 'Feedback' | 'Superactivity' | 'Skills' | 'Other'
+| 'TemporaryContent';
 
 export type TorusResourceType = Hierarchy | Page | Activity | Objective | Unknown;
 
@@ -44,6 +45,11 @@ export interface Objective {
 export interface Hierarchy extends TorusResource {
   type: 'Hierarchy';
   children: TorusResource[];
+}
+
+export interface TemporaryContent extends TorusResource {
+  type: 'TemporaryContent';
+  content: Object;
 }
 
 export interface Unknown extends TorusResource {

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -15,9 +15,9 @@ function getPastDocType(content: string): string {
 
 function inlineAttrName(attrs: any) {
   if (attrs['style'] === 'bold') {
-    return 'bold';
+    return 'strong';
   } else if (attrs['style'] === 'italic') {
-    return 'italic';
+    return 'em';
   } else if (attrs['style'] === 'code') {
     return 'code';
   } else if (attrs['style'] === 'sub') {
@@ -25,7 +25,7 @@ function inlineAttrName(attrs: any) {
   } else if (attrs['style'] === 'sup') {
     return 'sup';
   } else {
-    return 'bold';
+    return 'strong';
   }
 }
 


### PR DESCRIPTION
This PR adds support for preserving supporting content blocks within a formative assessment.  Previously these were being dropped on the floor as only the questions themselves were being preserved. 

This PR also makes a change to use the correct inline markup element names for Torus. 