### PR TITLE
ensure flattened file paths deconflict

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ function uploadAction() {
   const uploaders = manifest.mediaItems.map((m: any) => {
     return () => {
       console.log('Uploading ' + m.file);
-      return upload(m.file, m.name, slug);
+      return upload(m.file, m.name, m.mimeType, slug);
     };
   });
 

--- a/src/resources/image.ts
+++ b/src/resources/image.ts
@@ -198,7 +198,7 @@ function toActivity(content: any) {
     tags: [],
     unresolvedReferences: [],
     content,
-    objectives: [],
+    objectives: {},
     legacyId: id,
     subType: 'oli_image_coding',
   };

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -89,7 +89,7 @@ function toActivity(content: any, legacyId: string, subType: string, title: stri
     tags: [],
     unresolvedReferences: [],
     content,
-    objectives: [],
+    objectives: {},
     legacyId,
     subType,
   };

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -1,15 +1,16 @@
 const AWS = require('aws-sdk');
 const fs = require('fs');
 
-export const upload = (file: string, filename: string, slug: string) => {
+export const upload = (file: string, filename: string, mimeType: string, slug: string) => {
   // Read content from the file
   const fileContent = fs.readFileSync(file);
 
   // Setting up S3 upload parameters
   const params = {
-      Bucket: process.env.MEDIA_BUCKET_NAME,
-      Key: 'media/' + slug + '/' + filename,
-      Body: fileContent
+    Bucket: process.env.MEDIA_BUCKET_NAME,
+    Key: `media/${slug}/${filename}`,
+    Body: fileContent,
+    ContentType: mimeType,
   };
 
   const s3 = new AWS.S3({
@@ -19,7 +20,7 @@ export const upload = (file: string, filename: string, slug: string) => {
 
   // Uploading files to the bucket
   return new Promise((resolve, reject) => {
-    s3.upload(params, function(err: any, data: any) {
+    s3.upload(params, (err: any, data: any) => {
       if (err) {
         reject(err);
       }

--- a/test/content/x-oli-embed-activity/d9bd71f02ca144bf9246d0631cb2d086.xml
+++ b/test/content/x-oli-embed-activity/d9bd71f02ca144bf9246d0631cb2d086.xml
@@ -1,2 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE embed_activity PUBLIC "-//Carnegie Mellon University//DTD Embed 1.1//EN" "http://oli.cmu.edu/dtd/oli-embed-activity_1.0.dtd"><embed_activity id="d9bd71f02ca144bf9246d0631cb2d086" height="600" width="670" activity_type="REPL"><title>New REPL Activity</title><source>webcontent/repl/repl.js</source><assets><asset name="layout">webcontent/repl/d9bd71f02ca144bf9246d0631cb2d086/layout.html</asset><asset name="emstyles">webcontent/repl/emstyles.css</asset><asset name="controls">webcontent/repl/controls.html</asset><asset name="questions">webcontent/repl/d9bd71f02ca144bf9246d0631cb2d086/questions.xml</asset><asset name="solutions">webcontent/repl/d9bd71f02ca144bf9246d0631cb2d086/solutions.xml</asset></assets></embed_activity>
+<!DOCTYPE embed_activity PUBLIC "-//Carnegie Mellon University//DTD Embed 1.1//EN"
+        "http://oli.cmu.edu/dtd/oli-embed-activity_1.0.dtd">
+<embed_activity id="d9bd71f02ca144bf9246d0631cb2d086" height="600" width="670" activity_type="REPL">
+    <title>New REPL Activity</title>
+    <source>webcontent/repl/repl.js</source>
+    <assets>
+        <asset name="layout">webcontent/repl/d9bd71f02ca144bf9246d0631cb2d086/layout.html</asset>
+        <asset name="emstyles">webcontent/repl/emstyles.css</asset>
+        <asset name="controls">webcontent/repl/controls.html</asset>
+        <asset name="questions">webcontent/repl/d9bd71f02ca144bf9246d0631cb2d086/questions.xml</asset>
+        <asset name="solutions">webcontent/repl/d9bd71f02ca144bf9246d0631cb2d086/solutions.xml</asset>
+    </assets>
+</embed_activity>


### PR DESCRIPTION
This PR handles the case where multiple files in webcontent folders at various depths within a course package folder end up in the same location at the now flattened webcontent folder structure. The solution is to first sort by file path, then insert a guid into the file path at any subsequent path collision.

Example for the file structure below
package_name
--webcontent
----repl.js
--secondary_level
----webcontent
------repl.js

There resulting flattened webcontent folder would be
webcontent
--repl.js
--457383 (guid)
----repl.js

This PR fixes two other bugs. 

- Torus ingest failing due to expecting the objective object to be a map instead of a list
- Sets mime-type of files uploaded into S3. This allows files such as .css style files to work on browser 