### PR TITLE
[BUG FIX] remove node dependency for m1 chips

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "jest": "^26.6.3",
     "md5-file": "^5.0.0",
     "mime-types": "^2.1.29",
-    "node": "^14.8.0",
     "node-xml-stream-parser": "^1.0.12",
     "tmp": "^0.2.1",
     "tsmonad": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,9 +1736,9 @@ domutils@^1.5.1:
     domelementtype "1"
 
 dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -3484,11 +3484,6 @@ nice-try@^1.0.4:
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-bin-setup@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz"
-  integrity sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
@@ -3515,13 +3510,6 @@ node-xml-stream-parser@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/node-xml-stream-parser/-/node-xml-stream-parser-1.0.12.tgz"
   integrity sha512-qfUiDv1F6OMSltv2/ay32q7fp995OrA3TmEdlwFcxEjAQPiEAH+qi3jAh0QjOTXNbdLa5hoYhuBPCiylllGfjg==
-
-node@^14.8.0:
-  version "14.8.0"
-  resolved "https://registry.npmjs.org/node/-/node-14.8.0.tgz"
-  integrity sha512-F3hndEpkL32EaxbNawsUdMjQfPGAWvIlK8lMdQykI4Rp3dw/p9X1e0OFa0Tyvz1+hGefgT6lQWJ8wj1g/YvO9g==
-  dependencies:
-    node-bin-setup "^1.0.0"
 
 normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
This PR removes the "node" dependency from package.json in order to fix an issue installing dependencies using yarn on Mac machines that have M1 processors.