### PR TITLE
[BUGFIX] Fixes for missing questions, targeted feedback, title handling

### DIFF
--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -135,7 +135,7 @@ export function cata(question: any) {
     type: 'TargetedCATA',
     authoring: {
       parts: [buildCATAPart(question)],
-      transformations: [],
+      transformations: question.shuffle ? [Common.shuffleTransformation()] : [],
       previewText: '',
       targeted: [],
       correct: [],

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -24,6 +24,14 @@ export function buildStem(question: any) {
   };
 }
 
+export function shuffleTransformation() {
+  return {
+    id: guid(),
+    path: 'choices',
+    operation: 'shuffle',
+  };
+}
+
 export function buildChoices(question: any, from = 'multiple_choice') {
   const choices = getChild(question.children, from).children;
 

--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -10,6 +10,7 @@ import * as XML from '../utils/xml';
 export function convertToFormative($: any) {
   $('multiple_choice').each((i: any, item: any) => {
     DOM.moveAttrToChildren($, item, 'select', 'input');
+    DOM.moveAttrToChildren($, item, 'shuffle', 'input');
   });
 
   $('text').each((i: any, item: any) => {
@@ -86,7 +87,7 @@ export class Summative extends Resource {
     return new Promise((resolve, _reject) => {
       XML.toJSON(xml, { p: true, em: true, li: true, td: true }).then(
         (r: any) => {
-          const legacyId = r.id;
+          const legacyId = r.children[0].id;
 
           const { model, items, unresolvedReferences, title } =
             Formative.processAssessmentModel(legacyId, r.children[0].children);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -131,14 +131,14 @@ function handleLabelledContent($: any, selector: string) {
   const items = $(selector);
 
   items.each((i: any, elem: any) => {
-    const title = $(elem).children('title').text();
+    const title = $(elem).children('title').html();
     const caption = $(elem).children('caption').text();
 
-    const combined = (title + ' ' + caption).trim();
-
-    $(elem).attr('caption', combined);
+    $(elem).attr('caption', caption);
     $(elem).children().remove('title');
     $(elem).children().remove('caption');
+
+    $('<h5>' + title + '</h5>').insertBefore($(elem));
   });
 }
 


### PR DESCRIPTION
This PR fixes several issues that were observed during the QA phase of the Pcard and GUSIO courses.

1. https://github.com/Simon-Initiative/oli-torus/issues/2449 - Fixes title handling by converting `<title>` elements of tables and media elements to `<h5>` elements preceding the table or media element.   There is not a problem with the display of paragraphs within tables. The specific example cited in this bug is from a legacy page that contained a table within a list item.  This is not supported in Torus. Tables are top level block elements. 
2. https://github.com/Simon-Initiative/oli-torus/issues/2446 - After generation of a digest and local ingest, images from supporting content seem to be rendering fine now. 
3. https://github.com/Simon-Initiative/oli-torus/issues/2445 - Fixed by properly handling the `shuffle` attribute. 
4. https://github.com/Simon-Initiative/oli-torus/issues/2444 - Fixed by handling an edge case where there are only two choices and neither use the "catch all" rule. 
5. https://github.com/Simon-Initiative/oli-torus/issues/2455 - Fixed, the issue here is that the `course-digest` tool was treating question identifiers as globally unique to a course.  In Echo courses these ids are guids, which allow them to be globally unique, but in hand crafted courses there is no guarantee that these ids are globally unique.  In this course almost every formative and summative used the same question identification strategy: `mcq1`, `mcq2`, `mcq3`, etc.  This caused overwriting internally of these reused question ids, which lead to questions being dropped and in the case of formatives, questions appearing referenced from the wrong page. 
6. https://github.com/Simon-Initiative/oli-torus/issues/2453 - Fixed, same root case as number 5. 
7. https://github.com/Simon-Initiative/oli-torus/issues/2454 - Fixed, targeted feedback was not being set up correctly.  

