### PR TITLE
Migration fixes

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -51,7 +51,6 @@ function buildMCQPart(question: any) {
 
   const model = {
     id: '1',
-    version: 2,
     responses: r,
     hints: Common.ensureThree(
       hints.map((r: any) => ({
@@ -150,6 +149,7 @@ function mcq(question: any) {
     stem: Common.buildStem(question),
     choices: Common.buildChoices(question),
     authoring: {
+      version: 2,
       parts: [part],
       transformations:
         shuffle === 'true' ? [Common.shuffleTransformation()] : [],

--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -134,6 +134,7 @@ export function cata(question: any) {
     choices,
     type: 'TargetedCATA',
     authoring: {
+      version: 2,
       parts: [buildCATAPart(question)],
       transformations: question.shuffle ? [Common.shuffleTransformation()] : [],
       previewText: '',

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -22,6 +22,7 @@ export class WorkbookPage extends Resource {
     DOM.flattenNestedSections($);
     liftTitle($);
     DOM.rename($, 'wb\\:inline', 'activity_placeholder');
+    DOM.rename($, 'inline', 'activity_placeholder');
     DOM.rename($, 'activity', 'activity_placeholder');
     DOM.rename($, 'activity_link', 'a');
   }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -132,11 +132,7 @@ function handleLabelledContent($: any, selector: string) {
 
   items.each((i: any, elem: any) => {
     const title = $(elem).children('title').html();
-    const caption = $(elem).children('caption').text();
-
-    $(elem).attr('caption', caption);
     $(elem).children().remove('title');
-    $(elem).children().remove('caption');
 
     if (title) {
       $('<h5>' + title + '</h5>').insertBefore($(elem));

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -190,6 +190,26 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         }
       };
 
+      const elevateCaption = (parent: string) => {
+        if (tag === 'caption' && stack[stack.length - 2].type === parent) {
+          if (stack.length > 1) {
+            stack[stack.length - 2].caption = top().children;
+            stack[stack.length - 2].children = [{ type: 'text', text: ' ' }];
+          }
+        }
+      };
+
+      const elevateTableCaption = () => {
+        if (tag === 'caption' && stack[stack.length - 2].type === 'table') {
+          if (stack.length > 1) {
+            stack[stack.length - 2].caption = top().children;
+            stack[stack.length - 2].children = stack[
+              stack.length - 2
+            ].children.filter((t: any) => t.type !== 'caption');
+          }
+        }
+      };
+
       if (tag !== null) {
         ensureNotEmpty('p');
         ensureNotEmpty('th');
@@ -206,6 +226,11 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         ensureNotEmpty('youtube');
         ensureNotEmpty('audio');
         ensureNotEmpty('li');
+        elevateCaption('img');
+        elevateCaption('iframe');
+        elevateCaption('youtube');
+        elevateTableCaption();
+        elevateCaption('audio');
 
         if (top() && top().children === undefined) {
           top().children = [];


### PR DESCRIPTION
This fixes https://github.com/Simon-Initiative/oli-torus/issues/2495

Code within Torus was migrating ingested models to V2, since these were not being designated as V2.  This migration (correctly) sets the targeted feedback to an empty list.   By setting the version, we avoid the migration and preserve targeted feedback. 

Also, along with https://github.com/Simon-Initiative/oli-torus/pull/2499, this PR will fix the ability to allow captions with rich text to migrate correctly into Torus. The changes here are to preserve the HTML structure of the `caption` element and store it as the `caption` attribute (which used to simply be a string representation of the caption).

