### PR TITLE
Nested images

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -57,18 +57,27 @@ export function standardContentManipulations($: any) {
   DOM.flattenNestedSections($);
   DOM.removeSelfClosing($);
   DOM.mergeCaptions($);
+  // Default to block images
   DOM.rename($, 'image', 'img');
+  DOM.rename($, 'link', 'a');
+  // Images "nested" inside paragraphs and links become inline images.
+  // Block images are wrapped inside figures in Torus, so even if an
+  // image in a legacy course is intended as a block semantically, with
+  // newlines before or after, converting to inline images feels like
+  // a closer mapping to the correct rendering.
+  DOM.rename($, 'p img', 'img_inline');
+  DOM.rename($, 'a img', 'img_inline');
+  // Inline images should technically be valid in any Slate model element
+  // that supports inline elements, but we're only explicitly handling
+  // converting images in paragraphs and links (anchors).
   DOM.rename($, 'codeblock', 'code');
   DOM.renameAttribute($, 'code', 'syntax', 'language');
-  DOM.rename($, 'link', 'a');
 
   // Certain elements are not currently (and some may never be) supported
   // in Torus, so we remove them.  In this respect, OLI course conversion
   // is lossy wrt specific element constructs.
   $('popout').remove();
   $('sym').remove();
-  $('p img').remove();
-  $('link img').remove();
   $('applet').remove();
   $('director').remove();
   $('flash').remove();

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -222,6 +222,7 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         ensureDefaultText('h5', 'Section Header');
         ensureDefaultText('h6', 'Section Header');
         ensureNotEmpty('img');
+        ensureNotEmpty('img_inline');
         ensureNotEmpty('iframe');
         ensureNotEmpty('youtube');
         ensureNotEmpty('audio');

--- a/test/resources/common-test.ts
+++ b/test/resources/common-test.ts
@@ -1,5 +1,9 @@
-import { processCodeblock } from '../../src/resources/common';
+import {
+  processCodeblock,
+  standardContentManipulations,
+} from '../../src/resources/common';
 import * as cheerio from 'cheerio';
+import { toJSON } from '../../src/utils/xml';
 
 describe('cdata and codeblocks', () => {
   test('should strip the element', () => {
@@ -18,5 +22,44 @@ describe('cdata and codeblocks', () => {
         '<code_line><![CDATA[a]]></code_line><code_line><![CDATA[b]]></code_line>' +
         '</codeblock>'
     );
+  });
+
+  test('should convert root images to block imgs', async () => {
+    const content = '<image src="../webcontent/proof_prem.gif"/>';
+
+    const $ = cheerio.load(content, {
+      normalizeWhitespace: true,
+      xmlMode: true,
+    });
+
+    standardContentManipulations($);
+
+    const result: any = await toJSON($.xml());
+    const img = result.children[0];
+    expect(img.type).toBe('img');
+  });
+
+  test('should convert nested images to inline imgs', async () => {
+    const content1 = '<p><image src="../webcontent/proof_prem.gif"/></p>';
+    const content2 = '<a><image src="../webcontent/proof_prem.gif"/></a>';
+
+    const $1 = cheerio.load(content1, {
+      normalizeWhitespace: true,
+      xmlMode: true,
+    });
+    const $2 = cheerio.load(content2, {
+      normalizeWhitespace: true,
+      xmlMode: true,
+    });
+
+    standardContentManipulations($1);
+    const p1: any = await toJSON($1.xml());
+    const img1 = p1.children[0].children[0];
+    expect(img1.type).toBe('img_inline');
+
+    standardContentManipulations($2);
+    const p2: any = await toJSON($1.xml());
+    const img2 = p2.children[0].children[0];
+    expect(img2.type).toBe('img_inline');
   });
 });


### PR DESCRIPTION
Written to handle nested images in course migrations. the `img_inline` is a new slate element.

https://github.com/Simon-Initiative/oli-torus/issues/2451
https://github.com/Simon-Initiative/oli-torus/issues/2446