### PR TITLE
fix an issue where the pipe char is invalid filename character on windows platforms

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -108,8 +108,7 @@ export function globalizeObjectiveReferences(
   // id of the parent <objectives> element
   const localToGlobal = resources.reduce((m: any, r: TorusResource) => {
     if (r.type === 'Objective') {
-      const parts = r.id.split('|');
-      m[parts[0]] = r.id;
+      m[r.id] = `${r.id}-${r.parentId}`;
       return m;
     }
     return m;

--- a/src/resources/objectives.ts
+++ b/src/resources/objectives.ts
@@ -19,13 +19,13 @@ export class Objectives extends Resource {
     });
 
     $('objective').each((i: any, elem: any) => {
-      // This makes the id truly global
-      const id = $(elem).attr('id') + '|' + parentId;
+      const id = $(elem).attr('id');
       const title = $(elem).text().trim();
 
       const o = {
         type: 'Objective',
         id,
+        parentId,
         originalFile: '',
         title,
         tags: [],
@@ -34,14 +34,15 @@ export class Objectives extends Resource {
         objectives: [],
       } as TorusResource;
 
-      map[o.id] = o;
+      // parentId is necessary because it makes the id truly global
+      map[`${o.id}-${parentId}`] = o;
 
       objectives.push(o);
     });
 
     $('skillref').each((i: any, elem: any) => {
       const id = $(elem).attr('idref');
-      const actualParent = $(elem).parent().attr('idref') + '|' + parentId;
+      const actualParent = $(elem).parent().attr('idref') + '-' + parentId;
       const o = map[actualParent];
       o.objectives.push(id);
     });

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -35,6 +35,7 @@ export interface TorusResource {
   type: string;
   originalFile: string;
   id: string;
+  parentId?: string;
   title: string;
   tags: string[];
   unresolvedReferences: string[];


### PR DESCRIPTION
This PR fixes an issue where the pipe char is an invalid filename character on windows platforms. The fix here is to add the parentId to the Objective resource object and use '-' for concatenations when keying for maps.

Tested on Windows 10 using the following in command prompt:
```
ts-node src/index.ts "--operation" "convert" "--inputDir" ".\\test\\course_packages\\migration-4sdfykby_v_1_0-echo" "--specificOrg" "test\\course_packages\\migration-4sdfykby_v_1_0-echo\\organizations\\default\\organization.xml" "--specificOrgId" "migration-4sdfykby-1.0_default" "--outputDir" ".\\out" "--mediaUrlPrefix" "https://torus-media.s3.amazonaws.com/media"
```