### PR TITLE
add support for submit and compare

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -25,7 +25,7 @@ export function convert(
     const item = create(t, file, navigable);
 
     // print out current filename for progress/diagnostics
-    console.log(file);
+    console.log('Converting: ', file);
 
     let $ = DOM.read(file, { normalizeWhitespace: false });
     item.restructurePreservingWhitespace($);

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -201,8 +201,9 @@ function single_response_text(question: any) {
   return {
     stem: Common.buildStem(question),
     inputType: 'text',
+    submitAndCompare: Common.isSubmitAndCompare(question),
     authoring: {
-      parts: [Common.buildTextPart(question)],
+      parts: [Common.buildTextPart('1', question)],
       transformations: [],
       previewText: '',
     },

--- a/src/resources/webcontent.ts
+++ b/src/resources/webcontent.ts
@@ -13,39 +13,43 @@ export function addWebContentToMediaSummary(
   const getName = (file: string) => file.substr(file.lastIndexOf('webcontent'));
 
   return new Promise((resolve, _reject) => {
-    glob(`${directory}/**/webcontent/**/*.*`, {}, (err: any, files: any) => {
-      // Sort file paths by depth to ensure that shallower paths are processed first when a
-      // filename conflict, in the now relatively flatted webcontent file structure, is detected
-      files.sort((a: string, b: string) => {
-        return a.split('/').length - b.split('/').length;
-      });
+    glob(
+      `${directory}/**/webcontent/**/*`,
+      { nodir: true },
+      (err: any, files: any) => {
+        // Sort file paths by depth to ensure that shallower paths are processed first when a
+        // filename conflict, in the now relatively flatted webcontent file structure, is detected
+        files.sort((a: string, b: string) => {
+          return a.split('/').length - b.split('/').length;
+        });
 
-      files.forEach((file: string) => {
-        const absolutePath = path.resolve(file);
-        const name = getName(absolutePath);
-        const md5 = md5File.sync(absolutePath);
-        const toURL = (name: string) => `${summary.urlPrefix}/${md5}/${name}`;
+        files.forEach((file: string) => {
+          const absolutePath = path.resolve(file);
+          const name = getName(absolutePath);
+          const md5 = md5File.sync(absolutePath);
+          const toURL = (name: string) => `${summary.urlPrefix}/${md5}/${name}`;
 
-        if (summary.mediaItems[absolutePath] === undefined) {
-          const flattenedName = summary.flattenedNames[name]
-            ? generateNewName(name)
-            : name;
+          if (summary.mediaItems[absolutePath] === undefined) {
+            const flattenedName = summary.flattenedNames[name]
+              ? generateNewName(name)
+              : name;
 
-          summary.flattenedNames[flattenedName] = flattenedName;
-          summary.mediaItems[absolutePath] = {
-            file: absolutePath,
-            fileSize: getFilesizeInBytes(absolutePath),
-            name,
-            flattenedName,
-            md5,
-            mimeType: mime.lookup(absolutePath) || 'application/octet-stream',
-            references: [],
-            url: toURL(flattenedName),
-          };
-        }
-      });
-      resolve(summary);
-    });
+            summary.flattenedNames[flattenedName] = flattenedName;
+            summary.mediaItems[absolutePath] = {
+              file: absolutePath,
+              fileSize: getFilesizeInBytes(absolutePath),
+              name,
+              flattenedName,
+              md5,
+              mimeType: mime.lookup(absolutePath) || 'application/octet-stream',
+              references: [],
+              url: toURL(flattenedName),
+            };
+          }
+        });
+        resolve(summary);
+      }
+    );
   });
 }
 

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -9,6 +9,7 @@ import {
 import * as DOM from '../utils/dom';
 import * as XML from '../utils/xml';
 import { convertImageCodingActivities } from './image';
+import { maybe } from 'tsmonad';
 
 function liftTitle($: any) {
   $('workbook_page').attr('title', $('head title').text());
@@ -168,15 +169,19 @@ function introduceStructuredContent(content: any) {
         wrapContentInGroup(
           [
             asStructured({
-              children: [
-                {
-                  children: e.children.find((c: any) => c.type === 'title')
-                    .children,
-                  id: guid(),
-                  type: 'h2',
-                },
-                ...e.children.filter((c: any) => c.type !== 'title'),
-              ],
+              children: maybe(
+                e.children.find((c: any) => c.type === 'title')
+              ).caseOf({
+                just: (title: any) => [
+                  {
+                    children: title.children,
+                    id: guid(),
+                    type: 'h2',
+                  },
+                  ...e.children.filter((c: any) => c.type !== 'title'),
+                ],
+                nothing: () => e.children,
+              }),
             }),
           ],
           'example'

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,4 @@
+import * as util from 'util';
+
+export const inspect = (...args: any[]) =>
+  console.log(util.inspect(args, { showHidden: true, depth: null }));

--- a/test/convert-test.ts
+++ b/test/convert-test.ts
@@ -80,7 +80,7 @@ it('should convert example course to valid course digest', async () => {
       content: expect.objectContaining({ model: expect.any(Array) }),
       isGraded: false,
       objectives: [
-        'c47ac29051ed427984e2b6f76d09fa8e|dd83841bc84045138faf6f3b7868c6dc',
+        'c47ac29051ed427984e2b6f76d09fa8e-dd83841bc84045138faf6f3b7868c6dc',
       ],
     })
   );
@@ -159,7 +159,8 @@ it('should convert example course to valid course digest', async () => {
   expect(finalResources).toContainEqual(
     expect.objectContaining({
       type: 'Objective',
-      id: 'c47ac29051ed427984e2b6f76d09fa8e|dd83841bc84045138faf6f3b7868c6dc',
+      id: 'c47ac29051ed427984e2b6f76d09fa8e',
+      parentId: 'dd83841bc84045138faf6f3b7868c6dc',
       originalFile: '',
       title: 'Default objective',
       tags: [],

--- a/test/resources/questions/common-test.ts
+++ b/test/resources/questions/common-test.ts
@@ -1,0 +1,106 @@
+import { standardContentManipulations } from '../../../src/resources/common';
+import { isSubmitAndCompare } from '../../../src/resources/questions/common';
+import * as cheerio from 'cheerio';
+import { toJSON } from '../../../src/utils/xml';
+
+it('should return submitAndCompare status', async () => {
+  const content1 = `
+    <question id="_u02_m01_privs_DIGT_5_1">
+        <body>
+            <p id="faeee8c4de834e81ae1fe9b7780e2947">Which statement best describes the
+                university’s approach to enforcing the
+                <link
+                    href="https://www.cmu.edu/policies/information-technology/computing.html"
+                    target="new" internal="false"> Computing Policy</link>?
+            </p>
+        </body>
+        <multiple_choice shuffle="false" select="single" id="ans" labels="false">
+            <choice value="formal">The Computing Policy focuses on the consistent application of
+                formal penalties. </choice>
+            <choice value="informal">The Computing Policy has a range of penalties that are
+                applied based on intent and circumstance. </choice>
+        </multiple_choice>
+        <part id="e629bfc50e8345f38caba7e511874090">
+            <skillref idref="c984f86c2c3144a28ac35b1190ccd403"/>
+            <response match="formal" score="0">
+                <feedback>
+                    <p id="ace8e8424c5dd408aaf134451d8fc7830">Incorrect. The Computing
+                        Policy explicitly considers things like intent and history when
+                        enforcing violations.</p>
+                </feedback>
+            </response>
+            <response match="informal" score="1">
+                <feedback>
+                    <p id="abcc5ec52f3c84e28ba5c25e3e26a2303">Correct. Circumstances are
+                        considered carefully when enforcing the policy.</p>
+                </feedback>
+            </response>
+            <hint>
+                <p id="afdb39a44bf984064b3244e9b6e09035e">Does the computing policy contain a
+                    list of prohibited behaviors with the punishment for each?</p>
+            </hint>
+            <hint>
+                <p id="afcf9c3b9430b462994b7866a57215cf4">Are circumstances considered with
+                    enforcing the computing policy?</p>
+            </hint>
+        </part>
+    </question>
+  `;
+
+  const content2 = `
+    <question id="_u2_m1_privs_DIGT_5_3">
+        <body>
+            <p id="ba600545e35d45dfb825e1b841e7d9ae">Briefly summarize Carnegie Mellon&apos;s
+                approach to enforcement of the
+                <link
+                    href="https://www.cmu.edu/policies/information-technology/computing.html"
+                    target="new" internal="false"> Computing Policy</link>.
+            </p>
+        </body>
+        <short_answer id="choice" whitespace="trim" case_sensitive="false"/>
+        <part id="d5f7ac03ff49463a901241f9010d6b94">
+            <skillref idref="c984f86c2c3144a28ac35b1190ccd403"/>
+            <skillref idref="b3c03a99437a4a609290e729305035b9"/>
+            <response match="*" score="1" input="choice"/>
+            <hint>
+                <p id="af913d7a934944e6296999007f41549bc">Remember that the policy takes into
+                    account intent and circumstances. It also acts similar to a community
+                    standard guideline.</p>
+            </hint>
+            <explanation>
+                <p id="ab78f6f3270cd4e7ea5a470f7478d572b">Enforcement of the Computing
+                    Policy relies on general university policy and guidelines. This reflects the
+                    fact that computing standards are simply an extension of community standards
+                    for acceptable behavior. Because the range of possible offenses extends from
+                    the trivial to the very severe, the enforcement options are very broad,
+                    ranging from reprimands to legal action. The general approach to enforcement
+                    is to be very cognizant of specific circumstances. Accidental violations,
+                    for example, are likely to receive less severe penalties, while malicious or
+                    repeated offenses will increase the severity of penalties.</p>
+            </explanation>
+        </part>
+    </question>
+  `;
+
+  const getQuestionEl = (root) => root.children[0];
+
+  const $1 = cheerio.load(content1, {
+    normalizeWhitespace: true,
+    xmlMode: true,
+  });
+
+  const $2 = cheerio.load(content2, {
+    normalizeWhitespace: true,
+    xmlMode: true,
+  });
+
+  standardContentManipulations($1);
+  const root1: any = await toJSON($1.xml());
+  const question1: any = getQuestionEl(root1);
+  expect(isSubmitAndCompare(question1)).toBe(false);
+
+  standardContentManipulations($2);
+  const root2: any = await toJSON($2.xml());
+  const question2: any = getQuestionEl(root2);
+  expect(isSubmitAndCompare(question2)).toBe(true);
+});


### PR DESCRIPTION
This PR adds support for submit and compare. It also includes the following fixes:

- restore currently file output
- fix an issue where webcontent glob may return a directory
- fix an issue where title was assumed to always be present in example