### PR TITLE
[BUG FIX] handle activity elements

### DIFF
--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -28,7 +28,6 @@ export class WorkbookPage extends Resource {
     liftTitle($);
     DOM.rename($, 'wb\\:inline', 'activity_placeholder');
     DOM.rename($, 'inline', 'activity_placeholder');
-    DOM.rename($, 'activity', 'activity_placeholder');
     DOM.rename($, 'activity_link', 'a');
   }
 
@@ -47,6 +46,12 @@ export class WorkbookPage extends Resource {
 
     $('activity_placeholder').each((i: any, elem: any) => {
       page.unresolvedReferences.push($(elem).attr('idref'));
+    });
+
+    $('activity').each((i: any, elem: any) => {
+      const idref = $(elem).attr('idref');
+      page.unresolvedReferences.push(idref);
+      $(elem).replaceWith(`<p><a idref="${idref}">Click to begin</a></p>`);
     });
 
     $('objref').each((i: any, elem: any) => {


### PR DESCRIPTION
This PR fixes the problem where `<activity>` elements that referenced a summative assessment resulted in the parent practice page having the content and activities of the summative inlined.  The fix here is to simply insert a link to the summative.  

We likely will revisit this approach after reviewing options with the broader team, perhaps by creating an equivalent reference construct in Torus. 

Closes #41