### PR TITLE
[ENHANCEMENT] Add popup, formula and mathml support

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -1,6 +1,7 @@
 import { ItemReference, guid } from '../utils/common';
 import * as Histogram from '../utils/histogram';
 import * as DOM from '../utils/dom';
+import { Domain } from 'domain';
 
 export interface HasReferences {
   found: () => ItemReference[];
@@ -90,7 +91,6 @@ export function standardContentManipulations($: any) {
 
   DOM.stripElement($, 'li p');
   DOM.stripElement($, 'p quote');
-  DOM.stripElement($, 'p formula');
   DOM.stripElement($, 'materials material');
   DOM.stripElement($, 'materials');
 
@@ -109,6 +109,110 @@ export function standardContentManipulations($: any) {
   DOM.rename($, 'quote', 'blockquote');
 
   DOM.rename($, 'extra', 'popup');
+
+  handleFormulaMathML($);
+}
+
+export function handleFormulaMathML($: any) {
+  $('formula').each((i: any, item: any) => {
+    const subtype = determineFormulaType(item);
+    if (subtype === 'mathml') {
+      $(item).attr('src', getFirstMathML($, item));
+      item.children = [];
+    } else if (subtype === 'latex') {
+      $(item).attr('src', stripLatexDelimiters(item.children[0].data));
+      item.children = [];
+    }
+    $(item).attr('subtype', subtype);
+  });
+
+  // For formula inside of paragraphs, we know they are of the inline variety
+  DOM.rename($, 'p formula', 'formula_inline');
+
+  // All others, we must inspect their context to determine whether they are
+  // inline or block
+  $('formula').each((i: any, item: any) => {
+    if (DOM.isInlineElement($, item)) {
+      item.tagName = 'formula_inline';
+    }
+  });
+
+  // At this point, all remaining <m:math> or <math> elements must be "standalone",
+  // that is, they exist without <formula> as their direct parent.  They all also
+  // can only be inline, thus we can safely parent them all with <formula_inline>
+  const formula_inline = $(
+    '<formula_inline_temp subtype="mathml"></formula_inline_temp>'
+  );
+  $('m\\:math').wrap(formula_inline);
+  $('math').wrap(formula_inline);
+  $('formula_inline_temp').each((i: any, item: any) => {
+    item.tagName = 'formula_inline';
+    $(item).attr('src', getFirstMathML($, item));
+    item.children = [];
+  });
+}
+
+function getFirstMathML($: any, item: any) {
+  const text = $(item).html();
+
+  let firstMath = text.indexOf('<math');
+  if (firstMath === -1) {
+    firstMath = text.indexOf('<m:math');
+  }
+
+  let firstMathEnd = text.indexOf('</m:math>');
+  if (firstMathEnd !== -1) {
+    firstMathEnd = firstMathEnd + 9;
+  } else {
+    firstMathEnd = text.indexOf('</math>') + 7;
+  }
+
+  return text.substring(firstMath, firstMathEnd);
+}
+
+export function determineFormulaType(item: any) {
+  if (
+    item.children.length === 1 &&
+    item.children[0].type === 'text' &&
+    isLatexString(item.children[0].data)
+  ) {
+    return 'latex';
+  }
+
+  if (
+    item.children.some((c: any) => isMathTag(c)) &&
+    item.children.every((c: any) => isTextOrMathTag(c))
+  ) {
+    return 'mathml';
+  }
+  return 'richtext';
+}
+
+function isTextOrMathTag(e: any) {
+  return e.type === 'text' || isMathTag(e);
+}
+
+function isMathTag(e: any) {
+  return e.type === 'tag' && (e.name === 'm:math' || e.name === 'math');
+}
+
+function stripLatexDelimiters(s: string): string {
+  const trimmed = s.trim();
+  return trimmed.substring(2, trimmed.length - 2);
+}
+
+function isLatexString(s: string): boolean {
+  const trimmed = s.trim();
+  if (trimmed.startsWith('$$') && trimmed.endsWith('$$')) {
+    return true;
+  }
+  if (trimmed.startsWith('\\(') && trimmed.endsWith('\\)')) {
+    return true;
+  }
+  if (trimmed.startsWith('\\[') && trimmed.endsWith('\\]')) {
+    return true;
+  }
+  return false;
 }
 
 function getPurpose(purpose?: string) {

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -93,7 +93,7 @@ export function standardContentManipulations($: any) {
   DOM.stripElement($, 'p formula');
   DOM.stripElement($, 'materials material');
   DOM.stripElement($, 'materials');
-  DOM.stripElement($, 'anchor');
+
   $('pullout title').remove();
   DOM.stripElement($, 'pullout');
 
@@ -107,6 +107,8 @@ export function standardContentManipulations($: any) {
   DOM.rename($, 'dl', 'ul');
 
   DOM.rename($, 'quote', 'blockquote');
+
+  DOM.rename($, 'extra', 'popup');
 }
 
 function getPurpose(purpose?: string) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -43,3 +43,22 @@ export enum LegacyTypes {
 export function guid() {
   return `${Math.floor(Math.random() * Math.floor(Math.pow(2, 32) - 1))}`;
 }
+
+export function decodeEntities(encodedString: string) {
+  const translate_re = /&(nbsp|amp|quot|lt|gt);/g;
+  const translate = {
+    nbsp: ' ',
+    amp: '&',
+    quot: '"',
+    lt: '<',
+    gt: '>',
+  };
+  return encodedString
+    .replace(translate_re, (match, entity) => {
+      return (translate as any)[entity];
+    })
+    .replace(/&#(\d+);/gi, function (match, numStr) {
+      const num = parseInt(numStr, 10);
+      return String.fromCharCode(num);
+    });
+}

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -46,6 +46,50 @@ export function flattenResourceRefs($: any) {
   });
 }
 
+// Utility function that allows determining whether an instance of a mixed type element (e.g. formula) is
+// needs to be considered inline or block.
+export function isInlineElement($: any, elem: any) {
+  const parent = $(elem).parent();
+
+  if (
+    isOneOf(parent[0].name, ['li', 'td', 'th', 'choice', 'feedback', 'hint'])
+  ) {
+    if (parent[0].children.length === 1) {
+      return false;
+    }
+
+    return parent[0].children.some(
+      (c: any) => c.type === 'text' || (c.type == 'tag' && isInlineTag(c.name))
+    );
+  }
+  return false;
+}
+
+const inlineTags = {
+  em: true,
+  sub: true,
+  sup: true,
+  cite: true,
+  a: true,
+  link: true,
+  activity_link: true,
+  foreign: true,
+  ipa: true,
+  code: true,
+  var: true,
+  term: true,
+  extra: true,
+  text: true,
+};
+
+export function isInlineTag(tag: string) {
+  return (inlineTags as any)[tag] === true;
+}
+
+export function isOneOf(item: string, items: Array<string>) {
+  return items.some((i: string) => i === item);
+}
+
 export function moveAttrToChildren(
   $: any,
   item: any,

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,6 +1,7 @@
 // XML related utilities
 import * as stream from 'stream';
 import * as fs from 'fs';
+import { decodeEntities } from './common';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const xmlParser = require('./parser');
@@ -233,6 +234,15 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         }
       };
 
+      const unescapeFormulaSrc = () => {
+        if (
+          (tag === 'formula' || tag === 'formula_inline') &&
+          top().subtype !== 'richtext'
+        ) {
+          top().src = decodeEntities(top().src);
+        }
+      };
+
       if (tag !== null) {
         ensureNotEmpty('p');
         ensureNotEmpty('th');
@@ -256,6 +266,7 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         elevateTableCaption();
         elevateCaption('audio');
         elevatePopoverContent();
+        unescapeFormulaSrc();
 
         if (top() && top().children === undefined) {
           top().children = [];

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -190,6 +190,29 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         }
       };
 
+      const getOneOfType = (children: any, type: string) => {
+        const results = children.filter((t: any) => t.type === type);
+        if (results.length > 0) {
+          return results[0];
+        }
+        return null;
+      };
+
+      const elevatePopoverContent = () => {
+        if (tag === 'popup' && top().children.length === 2) {
+          const anchor = getOneOfType(top().children, 'anchor');
+          const meaning = getOneOfType(top().children, 'meaning');
+
+          if (anchor !== null && meaning !== null) {
+            const material = getOneOfType(meaning.children, 'material');
+
+            top().children = anchor.children;
+            top().content = material.children;
+            top().trigger = 'hover';
+          }
+        }
+      };
+
       const elevateCaption = (parent: string) => {
         if (tag === 'caption' && stack[stack.length - 2].type === parent) {
           if (stack.length > 1) {
@@ -232,6 +255,7 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         elevateCaption('youtube');
         elevateTableCaption();
         elevateCaption('audio');
+        elevatePopoverContent();
 
         if (top() && top().children === undefined) {
           top().children = [];

--- a/test/convert-test.ts
+++ b/test/convert-test.ts
@@ -37,6 +37,8 @@ it('should convert example course to valid course digest', async () => {
     mediaUrlPrefix: 'https://example-url-prefix',
   });
 
+  console.log(hierarchy);
+
   expect(hierarchy as Hierarchy).toEqual(
     expect.objectContaining({
       type: 'Hierarchy',
@@ -61,11 +63,13 @@ it('should convert example course to valid course digest', async () => {
           type: 'container',
           children: expect.any(Array),
           id: 'lesson1',
-          title: 'Lesson 1',
+          title: ' Lesson 1 ',
         }),
       ]),
     })
   );
+
+  console.log(finalResources);
 
   expect(finalResources).toContainEqual(
     expect.objectContaining({

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/newe6ddd6fec8f54749a037ef13abd8df93.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/newe6ddd6fec8f54749a037ef13abd8df93.xml
@@ -1,2 +1,117 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Assessment MathML 2.4//EN" "http://oli.web.cmu.edu/dtd/oli_assessment_mathml_2_4.dtd"><assessment xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="newe6ddd6fec8f54749a037ef13abd8df93" recommended_attempts="3" max_attempts="3"><title>Graded Assessment</title><page id="dd814516ea5345b68bf10fd40a487941"><title>Page 1</title><content available="always"><p id="aeedee35301e4919b2463fc376d5a285"><em>THIS IS EXAMPLE SUPPORTING CONTENT. PLEASE EDIT OR DELETE IT.</em></p><p id="a2d5eba2a07c4afebfb1d224fab8981d">Review the Policy Statement, Privileges and Responsibilities and Misuse and Inappropriate Behavior sections of the Computing Policy, then answer the following questions.</p></content><multiple_choice id="newe6ddd6fec8f54749a037ef13abd8df93_1a" grading="automatic" select="single"><body><p id="cf1293ee77c049cd8ef9458213523f74"><em>THIS IS AN EXAMPLE MULTIPLE CHOICE QUESTION. PLEASE EDIT OR DELETE IT.</em></p><p id="c464e67423d3434191d029ecc80ad25c">Albert sees that his girlfriend has written her password on a note beside her computer; he logs in and sends a joke email to one of her friends. This action is: </p></body><input shuffle="false" id="ans" labels="false"><choice value="yes">Acceptable</choice><choice value="no">Unacceptable</choice></input><part id="b64662bac2d4429398824d27a8f8a5dc"><response match="yes" score="0"><feedback><p id="da7f43e8e6424c91865ae9e0cd537fe1">Incorrect; using another student&apos;s password is not acceptable, even if it&apos;s left out in the open. Further, Albert has assumed his girlfriend&apos;s identity by using her account, which is also a violation of the Computing Policy.</p></feedback></response><response match="no" score="1"><feedback><p id="b5851d692214409093fcb63201ccd45b">Correct; this is a pretty clear violation of the policy, including using another person&apos;s account and impersonating another individual.</p></feedback></response></part></multiple_choice></page><page id="e497866ff13a4946a45f556ad7a75b16"><title>Page 2</title><content available="always"><p id="db2175de8dbf40978554beb8a2145fdd">Page 2 content</p></content><multiple_choice id="dd4cf0fba08646cba219f424f2c6058c" grading="automatic" select="single"><body><p id="d9b4eb87a1ed4d7da484240eada7b4f1" /></body><input shuffle="true" id="f6957cca88264e5b8c528cc967050115" labels="false"><choice value="e51f85b27ccc41889e7230a70d75d477" /><choice value="dd99b416e2f34aea91bf1846b477bb26" /></input><part id="b905d61963af4ca68dc3a42fd3102fcb"><response match="e51f85b27ccc41889e7230a70d75d477" score="1"><feedback><p id="fa3ace11b5724b92a98fdc3e349e80d9" /></feedback></response><response match="dd99b416e2f34aea91bf1846b477bb26" score="0"><feedback><p id="e92546e0e83b445ca3d1443ca35fa7ed" /></feedback></response></part></multiple_choice></page><page id="e9be15119e084f24b4abe89771dff937"><title>Page 3</title><multiple_choice id="bab083e445df49b48d2af9a98e93a0c0" grading="automatic" select="single"><body><p id="fb3b253912fd4540b7bafdf76ceb8aee">Page 3 multiple choice</p></body><input shuffle="true" id="b8a611461c4d45ef8a32c2b0c2872be9" labels="false"><choice value="dc22d5fad3724547998cdaf700a51d5f" /><choice value="bbeed816b310495da616aead90915d58" /></input><part id="f400e35c4c5c4522a8cd1fadc84db35c"><response match="dc22d5fad3724547998cdaf700a51d5f" score="1"><feedback><p id="f84826fef5494926bb99f459d1b50b9c" /></feedback></response><response match="bbeed816b310495da616aead90915d58" score="0"><feedback><p id="a2928e297dff466e84e4f67f298fc2ee" /></feedback></response></part></multiple_choice></page></assessment>
+<!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Assessment MathML 2.4//EN" "http://oli.web.cmu.edu/dtd/oli_assessment_mathml_2_4.dtd">
+<assessment xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="newe6ddd6fec8f54749a037ef13abd8df93" recommended_attempts="3" max_attempts="3">
+	<title>
+		Graded Assessment
+	</title>
+	<page id="dd814516ea5345b68bf10fd40a487941">
+		<title>
+			Page 1
+		</title>
+		<content available="always">
+			<p id="aeedee35301e4919b2463fc376d5a285">
+				<em>
+					THIS IS EXAMPLE SUPPORTING CONTENT. PLEASE EDIT OR DELETE IT.
+				</em>
+			</p>
+			<p id="a2d5eba2a07c4afebfb1d224fab8981d">
+				Review the Policy Statement, Privileges and Responsibilities and Misuse and Inappropriate Behavior sections of the Computing Policy, then answer the following questions.
+			</p>
+		</content>
+		<multiple_choice id="newe6ddd6fec8f54749a037ef13abd8df93_1a" grading="automatic" select="single">
+			<body>
+				<p id="cf1293ee77c049cd8ef9458213523f74">
+					<em>
+						THIS IS AN EXAMPLE MULTIPLE CHOICE QUESTION. PLEASE EDIT OR DELETE IT.
+					</em>
+				</p>
+				<p id="c464e67423d3434191d029ecc80ad25c">
+					Albert sees that his girlfriend has written her password on a note beside her computer; he logs in and sends a joke email to one of her friends. This action is:
+				</p>
+			</body>
+			<input shuffle="false" id="ans" labels="false">
+				<choice value="yes">
+					Acceptable
+				</choice>
+				<choice value="no">
+					Unacceptable
+				</choice>
+			</input>
+			<part id="b64662bac2d4429398824d27a8f8a5dc">
+				<response match="yes" score="0">
+					<feedback>
+						<p id="da7f43e8e6424c91865ae9e0cd537fe1">
+							Incorrect; using another student&apos;s password is not acceptable, even if it&apos;s left out in the open. Further, Albert has assumed his girlfriend&apos;s identity by using her account, which is also a violation of the Computing Policy.
+						</p>
+					</feedback>
+				</response>
+				<response match="no" score="1">
+					<feedback>
+						<p id="b5851d692214409093fcb63201ccd45b">
+							Correct; this is a pretty clear violation of the policy, including using another person&apos;s account and impersonating another individual.
+						</p>
+					</feedback>
+				</response>
+			</part>
+		</multiple_choice>
+	</page>
+	<page id="e497866ff13a4946a45f556ad7a75b16">
+		<title>
+			Page 2
+		</title>
+		<content available="always">
+			<p id="db2175de8dbf40978554beb8a2145fdd">
+				Page 2 content
+			</p>
+		</content>
+		<multiple_choice id="dd4cf0fba08646cba219f424f2c6058c" grading="automatic" select="single">
+			<body>
+				<p id="d9b4eb87a1ed4d7da484240eada7b4f1" />
+			</body>
+			<input shuffle="true" id="f6957cca88264e5b8c528cc967050115" labels="false">
+				<choice value="e51f85b27ccc41889e7230a70d75d477" />
+				<choice value="dd99b416e2f34aea91bf1846b477bb26" />
+			</input>
+			<part id="b905d61963af4ca68dc3a42fd3102fcb">
+				<response match="e51f85b27ccc41889e7230a70d75d477" score="1">
+					<feedback>
+						<p id="fa3ace11b5724b92a98fdc3e349e80d9" />
+					</feedback>
+				</response>
+				<response match="dd99b416e2f34aea91bf1846b477bb26" score="0">
+					<feedback>
+						<p id="e92546e0e83b445ca3d1443ca35fa7ed" />
+					</feedback>
+				</response>
+			</part>
+		</multiple_choice>
+	</page>
+	<page id="e9be15119e084f24b4abe89771dff937">
+		<title>
+			Page 3
+		</title>
+		<multiple_choice id="bab083e445df49b48d2af9a98e93a0c0" grading="automatic" select="single">
+			<body>
+				<p id="fb3b253912fd4540b7bafdf76ceb8aee">
+					Page 3 multiple choice
+				</p>
+			</body>
+			<input shuffle="true" id="b8a611461c4d45ef8a32c2b0c2872be9" labels="false">
+				<choice value="dc22d5fad3724547998cdaf700a51d5f" />
+				<choice value="bbeed816b310495da616aead90915d58" />
+			</input>
+			<part id="f400e35c4c5c4522a8cd1fadc84db35c">
+				<response match="dc22d5fad3724547998cdaf700a51d5f" score="1">
+					<feedback>
+						<p id="f84826fef5494926bb99f459d1b50b9c" />
+					</feedback>
+				</response>
+				<response match="bbeed816b310495da616aead90915d58" score="0">
+					<feedback>
+						<p id="a2928e297dff466e84e4f67f298fc2ee" />
+					</feedback>
+				</response>
+			</part>
+		</multiple_choice>
+	</page>
+</assessment>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/extra.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/extra.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="extra">
+	<head>
+		<title>
+			Extra rollover
+		</title>
+		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+	</head>
+	<body>
+		<p>
+			There should be two popups in the following paragraphs, enabled via hover over the words
+			<em>
+				electrolytes
+			</em>
+			and
+			<em>
+				strong electrolytes
+			</em>
+		</p>
+		<p>
+			One important property of the resulting solution is its ability to conduct electricity.
+			Conductivity of a solution can be tested with an apparatus such as the one seen below.
+			Solutions that contain charged particles (ions) allow the electric current to flow
+			between the anodes. This will complete the circuit and cause the light bulb to light up.
+			Substances, like NaCl, that conduct electricity when dissolved in water are called
+			<extra>
+				<anchor>
+					electrolytes
+				</anchor>
+				<meaning>
+					<material>
+						<p>
+							substances that produces ions when dissolved in water
+						</p>
+					</material>
+				</meaning>
+			</extra>
+			. More specifically NaCl is a
+			<extra>
+				<anchor>
+					strong electrolyte
+				</anchor>
+				<meaning>
+					<material>
+						<p>
+							substance that dissociates or ionizes completely when dissolved in
+							water
+						</p>
+					</material>
+				</meaning>
+			</extra>
+			because it conducts electricity very well.
+		</p>
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/mathml.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/mathml.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="mathml">
+	<head>
+		<title>
+			MathML and Formula Ingest
+		</title>
+		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+	</head>
+	<body>
+		<p>
+			The following test cases exist:
+		</p>
+		<ol>
+			<li>
+				Block level formula with plain text
+			</li>
+			<li>
+				Block level formula with markup and text
+			</li>
+			<li>
+				Block level formula containing escaped Latex
+			</li>
+			<li>
+				Block level formula containing MathML
+			</li>
+			<li>
+				Inline formula with plain text
+			</li>
+			<li>
+				Inline formula with markup and text
+			</li>
+			<li>
+				Inline formula containing escaped Latex
+			</li>
+			<li>
+				Inline formula containing MathML
+			</li>
+			<li>
+				Standalone, inline Latex with inline escape
+			</li>
+			<li>
+				Standalone, inline Latex with block escape
+			</li>
+			<li>
+				Standalone, inline MathML with inline setting
+			</li>
+			<li>
+				Standalone, inline MathML with block setting
+			</li>
+			<li>
+				MathML appearing as the only entry within a table cell
+			</li>
+		</ol>
+		<p>
+			1. Block level formula with plain text
+		</p>
+		<formula>
+			A + B ⇌ C + D
+		</formula>
+		<p>
+			2. Block level formula with markup
+		</p>
+		<formula>
+			<em>
+				Emphasis
+			</em>
+			<sup>
+				2
+			</sup>
+		</formula>
+		<p>
+			3. Block level formula with Latex
+		</p>
+		<formula>
+			$${\mathrm M}_1{\mathrm L}_1\;=\;{\mathrm M}_2{\mathrm L}_2$$
+		</formula>
+		<p>
+			4. Block level formula with MathML
+		</p>
+		<formula>
+			<math display="block">
+				<mrow>
+					<mn>
+						0
+					</mn>
+					<mtext>
+						&nbsp;
+					</mtext>
+					<mo lspace="0px" rspace="0px">
+						=
+					</mo>
+					<mtext>
+						&nbsp;Δ
+					</mtext>
+					<mi>
+						G
+					</mi>
+					<mo lspace="0px" rspace="0px">
+						°
+					</mo>
+					<mtext>
+						&nbsp;
+					</mtext>
+					<mo lspace="0px" rspace="0px">
+						+
+					</mo>
+					<mtext>
+						&nbsp;
+					</mtext>
+					<mi>
+						RT
+					</mi>
+					<mtext>
+						ln
+					</mtext>
+					<mi>
+						K
+					</mi>
+					<mtext>
+						&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;
+					</mtext>
+					<mo fence="false" stretchy="false">
+						(
+					</mo>
+					<mi>
+						at
+					</mi>
+					<mo>
+						&nbsp;
+					</mo>
+					<mi>
+						equilibrium
+					</mi>
+					<mo fence="false" stretchy="false" form="infix">
+						)
+					</mo>
+				</mrow>
+			</math>
+		</formula>
+		<p>
+			5. Inline formula with plain text:
+			<formula>
+				This is the text
+			</formula>
+		</p>
+		<p>
+			6. Inline formula with markup and text:
+			<formula>
+				This is
+				<em>
+					bolded
+				</em>
+			</formula>
+		</p>
+		<p>
+			7. Inline formula Latex with inline escape
+			<formula>
+				\(=\;\frac{(3.6\times10^{-4})^2}{(0.036)(0.0089)}\)
+			</formula>
+			and one with a block escape:
+			<formula>
+				$$=\;\frac{(3.6\times10^{-4})^2}{(0.036)(0.0089)}$$
+			</formula>
+		</p>
+		<p>
+			8. Inline formula with MathMl with inline setting, including namespace:
+			<formula>
+				<m:math style="inline">
+					<m:mo>
+						&#x21CC;
+					</m:mo>
+				</m:math>
+			</formula>
+			And one with a block setting
+			<formula>
+				<math style="block">
+					<mo>
+						&#x21CC;
+					</mo>
+				</math>
+			</formula>
+		</p>
+		<p>
+			9. Standalone Latex with inline \(=\;\frac{(3.6\times10^{-4})^2}{(0.036)(0.0089)}\)
+		</p>
+		<p>
+			10. Standalone Latex with block $$=\;\frac{(3.6\times10^{-4})^2}{(0.036)(0.0089)}$$
+		</p>
+		<p>
+			11. Standalone MathML with inline
+			<math style="inline">
+				<mo>
+					&#x21CC;
+				</mo>
+			</math>
+		</p>
+		<p>
+			12. Standalone MathML with block
+			<math style="block">
+				<mo>
+					&#x21CC;
+				</mo>
+			</math>
+		</p>
+		<p>
+			13. MathML appearing as the only thing within a table cell (header in this example):
+		</p>
+		<table>
+			<tr>
+				<th>
+					<em style="italic">
+						T
+					</em>
+					(K)
+				</th>
+				<th>
+					<em style="italic">
+						k
+					</em>
+					(L/mol/s)
+				</th>
+				<th>
+					<math display="inline">
+						<mrow>
+							<mfrac>
+								<mn>
+									1
+								</mn>
+								<mi>
+									T
+								</mi>
+							</mfrac>
+						</mrow>
+					</math>
+					(K
+					<sup>
+						−1
+					</sup>
+					)
+				</th>
+				<th>
+					ln
+					<em style="italic">
+						k
+					</em>
+				</th>
+			</tr>
+			<tr>
+				<td>
+					703
+				</td>
+				<td>
+					1.1 × 10
+					<sup>
+						−2
+					</sup>
+				</td>
+				<td>
+					0.001422
+				</td>
+				<td>
+					-4.510
+				</td>
+			</tr>
+			<tr>
+				<td>
+					865
+				</td>
+				<td>
+					4.95
+				</td>
+				<td>
+					0.001156
+				</td>
+				<td>
+					1.600
+				</td>
+			</tr>
+		</table>
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/welcome.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/welcome.xml
@@ -11,40 +11,6 @@
 		<p id="c970f9059f4f4ac3a0b5f417f1f82acf">
 			(This space intentionally left blank.)
 		</p>
-		<p>
-			One important property of the resulting solution is its ability to conduct electricity.
-			Conductivity of a solution can be tested with an apparatus such as the one seen below.
-			Solutions that contain charged particles (ions) allow the electric current to flow
-			between the anodes. This will complete the circuit and cause the light bulb to light up.
-			Substances, like NaCl, that conduct electricity when dissolved in water are called
-			<extra>
-				<anchor>
-					electrolytes
-				</anchor>
-				<meaning>
-					<material>
-						<p>
-							substances that produces ions when dissolved in water
-						</p>
-					</material>
-				</meaning>
-			</extra>
-			. More specifically NaCl is a
-			<extra>
-				<anchor>
-					strong electrolyte
-				</anchor>
-				<meaning>
-					<material>
-						<p>
-							substance that dissociates or ionizes completely when dissolved in
-							water
-						</p>
-					</material>
-				</meaning>
-			</extra>
-			because it conducts electricity very well.
-		</p>
 		<example id="a088625f4d624799b370bc3d6e6a9677">
 			<title>
 				Example Title

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/welcome.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/welcome.xml
@@ -1,2 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd"><workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="welcome"><head><title>Welcome!</title><objref idref="c47ac29051ed427984e2b6f76d09fa8e" /></head><body><p id="c970f9059f4f4ac3a0b5f417f1f82acf">(This space intentionally left blank.)</p><example id="a088625f4d624799b370bc3d6e6a9677"><title>Example Title</title><p id="e1f96ce25cc14278ae759e14b08c44ff">This is an example</p></example><wb:inline idref="newca1a54a0f56a4d429f5aff2c515cab08" purpose="learnbydoing" /><activity idref="newc72f87db5a5543b5ae8582d2d4cd34a7" purpose="quiz" /></body></workbook_page>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="welcome">
+	<head>
+		<title>
+			Welcome!
+		</title>
+		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+	</head>
+	<body>
+		<p id="c970f9059f4f4ac3a0b5f417f1f82acf">
+			(This space intentionally left blank.)
+		</p>
+		<p>
+			One important property of the resulting solution is its ability to conduct electricity.
+			Conductivity of a solution can be tested with an apparatus such as the one seen below.
+			Solutions that contain charged particles (ions) allow the electric current to flow
+			between the anodes. This will complete the circuit and cause the light bulb to light up.
+			Substances, like NaCl, that conduct electricity when dissolved in water are called
+			<extra>
+				<anchor>
+					electrolytes
+				</anchor>
+				<meaning>
+					<material>
+						<p>
+							substances that produces ions when dissolved in water
+						</p>
+					</material>
+				</meaning>
+			</extra>
+			. More specifically NaCl is a
+			<extra>
+				<anchor>
+					strong electrolyte
+				</anchor>
+				<meaning>
+					<material>
+						<p>
+							substance that dissociates or ionizes completely when dissolved in
+							water
+						</p>
+					</material>
+				</meaning>
+			</extra>
+			because it conducts electricity very well.
+		</p>
+		<example id="a088625f4d624799b370bc3d6e6a9677">
+			<title>
+				Example Title
+			</title>
+			<p id="e1f96ce25cc14278ae759e14b08c44ff">
+				This is an example
+			</p>
+		</example>
+		<inline idref="newca1a54a0f56a4d429f5aff2c515cab08" purpose="learnbydoing" />
+		<activity idref="newc72f87db5a5543b5ae8582d2d4cd34a7" purpose="quiz" />
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -1,2 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE organization PUBLIC "-//Carnegie Mellon University//DTD Content Organization Simple 2.3//EN" "http://oli.web.cmu.edu/dtd/oli_content_organization_simple_2_3.dtd"><organization id="migration-4sdfykby-1.0_default" version="1.0"><title>Default Organization</title><description>Sample organization included with the OLI project template.</description><audience>This organization is intended as an example for OLI content authors.</audience><labels sequence="Sequence" unit="Unit" module="Module" section="Section" /><sequences><sequence id="part1" category="content" audience="all"><title>Project Template</title><unit id="lesson1"><title>Lesson 1</title><module id="introduction"><title>Introduction</title><item id="bca2e8dcf45e4ca5889891c18a62d648" scoring_mode="default"><resourceref idref="welcome" /></item><item id="ebe32e4f2039442896f67b64a54acd0d" scoring_mode="default"><resourceref idref="newe6ddd6fec8f54749a037ef13abd8df93" /></item></module></unit></sequence></sequences></organization>
+<!DOCTYPE organization PUBLIC "-//Carnegie Mellon University//DTD Content Organization Simple 2.3//EN" "http://oli.web.cmu.edu/dtd/oli_content_organization_simple_2_3.dtd">
+<organization id="migration-4sdfykby-1.0_default" version="1.0">
+	<title>
+		Default Organization
+	</title>
+	<description>
+		Sample organization included with the OLI project template.
+	</description>
+	<audience>
+		This organization is intended as an example for OLI content authors.
+	</audience>
+	<labels sequence="Sequence" unit="Unit" module="Module" section="Section" />
+	<sequences>
+		<sequence id="part1" category="content" audience="all">
+			<title>
+				Project Template
+			</title>
+			<unit id="lesson1">
+				<title>
+					Lesson 1
+				</title>
+				<module id="introduction">
+					<title>
+						Introduction
+					</title>
+					<item id="bca2e8dcf45e4ca5889891c18a62d648" scoring_mode="default">
+						<resourceref idref="welcome" />
+					</item>
+					<item id="ebe32e4f2039442896f67b64a54acd0d" scoring_mode="default">
+						<resourceref idref="newe6ddd6fec8f54749a037ef13abd8df93" />
+					</item>
+				</module>
+				<module id="corecomponents">
+					<title>
+						Core Page Components
+					</title>
+					<item id="bca2e8dcf45e4ca5889891c18a62d699" scoring_mode="default">
+						<resourceref idref="extra" />
+					</item>
+					<item id="bca2e8dcf45e4ca5889891c18a62d699" scoring_mode="default">
+						<resourceref idref="mathml" />
+					</item>
+				</module>
+			</unit>
+		</sequence>
+	</sequences>
+</organization>

--- a/test/resources/formula-math-test.ts
+++ b/test/resources/formula-math-test.ts
@@ -1,0 +1,108 @@
+import { handleFormulaMathML } from '../../src/resources/common';
+import * as cheerio from 'cheerio';
+
+function process(xml: string): any {
+  const $ = cheerio.load(xml, {
+    normalizeWhitespace: false,
+    xmlMode: true,
+  });
+  handleFormulaMathML($);
+  return $.xml();
+}
+
+describe('formulas and mathml', () => {
+  test('should properly identify and convert inlines', () => {
+    expect(
+      process('<body><formula>test</formula><p>test</p></body>').indexOf(
+        'formula_inline'
+      )
+    ).toEqual(-1);
+
+    expect(
+      process('<body><formula>test</formula></body>').indexOf('formula_inline')
+    ).toEqual(-1);
+
+    expect(
+      process('<td><formula>test</formula><p>test</p></td>').indexOf(
+        'formula_inline'
+      )
+    ).toEqual(-1);
+
+    expect(
+      process('<td>test <formula>test</formula></td>').indexOf('formula_inline')
+    ).toBeGreaterThan(-1);
+  });
+
+  test('should properly identify and convert latex formulas', () => {
+    let s = process('<body><formula>$$\\frac{2}{3}$$</formula></body>');
+    expect(s.indexOf('subtype="latex"')).toBeGreaterThan(-1);
+    expect(s.indexOf('src="\\frac{2}{3}"')).toBeGreaterThan(-1);
+
+    s = process('<body><formula>\\[\\frac{2}{3}\\]</formula></body>');
+    expect(s.indexOf('subtype="latex"')).toBeGreaterThan(-1);
+    expect(s.indexOf('src="\\frac{2}{3}"')).toBeGreaterThan(-1);
+
+    s = process('<body><formula>\\(\\frac{2}{3}\\)</formula></body>');
+    expect(s.indexOf('subtype="latex"')).toBeGreaterThan(-1);
+    expect(s.indexOf('src="\\frac{2}{3}"')).toBeGreaterThan(-1);
+  });
+
+  test('should properly identify and convert mathml formulas', () => {
+    let s = process(
+      '<body><formula><m:math><m:row/></m:math></formula></body>'
+    );
+    expect(s.indexOf('subtype="mathml"')).toBeGreaterThan(-1);
+    expect(
+      s.indexOf('src="&lt;m:math&gt;&lt;m:row/&gt;&lt;/m:math&gt;"')
+    ).toBeGreaterThan(-1);
+
+    // Ensure it handles math without namespace
+    s = process('<body><formula><math><row/></math></formula></body>');
+    expect(s.indexOf('subtype="mathml"')).toBeGreaterThan(-1);
+    expect(
+      s.indexOf('src="&lt;math&gt;&lt;row/&gt;&lt;/math&gt;"')
+    ).toBeGreaterThan(-1);
+
+    // Ensure it strips out extra mixed text
+    s = process(
+      '<body><formula>Good <math><row/></math> Luck</formula></body>'
+    );
+    expect(s.indexOf('subtype="mathml"')).toBeGreaterThan(-1);
+    expect(
+      s.indexOf('src="&lt;math&gt;&lt;row/&gt;&lt;/math&gt;"')
+    ).toBeGreaterThan(-1);
+
+    // Ensure it strips out any math beyond the first one
+    s = process(
+      '<body><formula>Good <math><row/></math><math><row/></math> Luck</formula></body>'
+    );
+    expect(s.indexOf('subtype="mathml"')).toBeGreaterThan(-1);
+    expect(
+      s.indexOf('src="&lt;math&gt;&lt;row/&gt;&lt;/math&gt;"')
+    ).toBeGreaterThan(-1);
+  });
+
+  test('should properly identify and convert richtext formulas', () => {
+    const s = process('<body><formula>plain text</formula></body>');
+    expect(s.indexOf('subtype="richtext"')).toBeGreaterThan(-1);
+    expect(s.indexOf('plain text</formula>')).toBeGreaterThan(-1);
+
+    expect(s.indexOf('src=')).toEqual(-1);
+  });
+
+  test('should reparent standalone math', () => {
+    let s = process('<body><p><m:math><m:row/></m:math></p></body>');
+    expect(s.indexOf('formula_inline')).toBeGreaterThan(-1);
+    expect(s.indexOf('subtype="mathml"')).toBeGreaterThan(-1);
+    expect(
+      s.indexOf('src="&lt;m:math&gt;&lt;m:row/&gt;&lt;/m:math&gt;"')
+    ).toBeGreaterThan(-1);
+
+    s = process('<body><p><math><row/></math></p></body>');
+    expect(s.indexOf('formula_inline')).toBeGreaterThan(-1);
+    expect(s.indexOf('subtype="mathml"')).toBeGreaterThan(-1);
+    expect(
+      s.indexOf('src="&lt;math&gt;&lt;row/&gt;&lt;/math&gt;"')
+    ).toBeGreaterThan(-1);
+  });
+});

--- a/test/resources/formula-math-test.ts
+++ b/test/resources/formula-math-test.ts
@@ -14,22 +14,20 @@ describe('formulas and mathml', () => {
   test('should properly identify and convert inlines', () => {
     expect(
       process('<body><formula>test</formula><p>test</p></body>').indexOf(
-        'formula_inline'
+        'callout'
       )
-    ).toEqual(-1);
+    ).toBeGreaterThan(-1);
 
     expect(
-      process('<body><formula>test</formula></body>').indexOf('formula_inline')
-    ).toEqual(-1);
+      process('<body><formula>test</formula></body>').indexOf('callout')
+    ).toBeGreaterThan(-1);
 
     expect(
-      process('<td><formula>test</formula><p>test</p></td>').indexOf(
-        'formula_inline'
-      )
-    ).toEqual(-1);
+      process('<td><formula>test</formula><p>test</p></td>').indexOf('callout')
+    ).toBeGreaterThan(-1);
 
     expect(
-      process('<td>test <formula>test</formula></td>').indexOf('formula_inline')
+      process('<td>test <formula>test</formula></td>').indexOf('callout_inline')
     ).toBeGreaterThan(-1);
   });
 
@@ -84,10 +82,9 @@ describe('formulas and mathml', () => {
 
   test('should properly identify and convert richtext formulas', () => {
     const s = process('<body><formula>plain text</formula></body>');
-    expect(s.indexOf('subtype="richtext"')).toBeGreaterThan(-1);
-    expect(s.indexOf('plain text</formula>')).toBeGreaterThan(-1);
-
-    expect(s.indexOf('src=')).toEqual(-1);
+    expect(s.indexOf('<callout><p>plain text</p></callout>')).toBeGreaterThan(
+      -1
+    );
   });
 
   test('should reparent standalone math', () => {

--- a/test/utils/dom-test.ts
+++ b/test/utils/dom-test.ts
@@ -4,10 +4,41 @@ import {
   stripElement,
   moveAttrToChildren,
   mergeCaptions,
+  isInlineElement,
 } from '../../src/utils/dom';
 import * as cheerio from 'cheerio';
 
 describe('dom mutations', () => {
+  test('should return that the formula is not inline', () => {
+    const content = '<td><formula>test</formula></td>';
+
+    const $ = cheerio.load(content, {
+      normalizeWhitespace: true,
+      xmlMode: true,
+    });
+
+    const refs = $('formula');
+
+    refs.each((i: any, elem: any) => {
+      expect(isInlineElement($, elem)).toBeFalsy();
+    });
+  });
+
+  test('should return that the formula is inline', () => {
+    const content = '<td>This is some <formula>test</formula></td>';
+
+    const $ = cheerio.load(content, {
+      normalizeWhitespace: true,
+      xmlMode: true,
+    });
+
+    const refs = $('formula');
+
+    refs.each((i: any, elem: any) => {
+      expect(isInlineElement($, elem)).toBeTruthy();
+    });
+  });
+
   test('should strip the element', () => {
     const content = '<p>1<b>2</b>3<b><c/></b></p>';
 


### PR DESCRIPTION
This PR provides support for migrating `<extra>` tag into the Torus popup construct.  

The `extra.xml` file within the embedded test course contains two instances of these elements. I've tested and they ingest correctly. 

This PR also implements support for `<formula>` elements, both inline and block, with proper Torus conversion to handle the three different subtypes: `mathml`, `latex` and `richtext`.    The `richtext` variety gets converted to the new `callout` and `callout_inline` structures within Torus. 

The `mathml.xml` resource demonstrates many different cases that must be supported.  NOTE: one can ingest the generated digest from the embedded test course and render it from Torus, but one cannot edit pages that contain formulas as the Authoring support is still a work in progress. 

One can now test this end-to-end by converting the embedded test course, then ingesting it into Torus.  You should be able to edit ingested formulas and callouts, and publish and access these as students. 