### PR TITLE
[FEATURE] Support Materials element

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -58,8 +58,9 @@ export function transformToFlatDirectory(
 
     // Update the URL in the XML DOM
     if (url !== null) {
-      const elem = paths[assetReference];
-      $(elem).attr('src', url);
+      paths[assetReference].forEach((elem) => {
+        $(elem).attr('src', url);
+      });
     }
   });
 }
@@ -156,23 +157,23 @@ export function stage(
   );
 }
 
-function findFromDOM($: any): string[] {
+function findFromDOM($: any): Record<string, Array<string>> {
   const paths: any = {};
 
   $('image').each((i: any, elem: any) => {
-    paths[$(elem).attr('src')] = elem;
+    paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
   });
 
   $('audio').each((i: any, elem: any) => {
-    paths[$(elem).attr('src')] = elem;
+    paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
   });
 
   $('audio source').each((i: any, elem: any) => {
-    paths[$(elem).attr('src')] = elem;
+    paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
   });
 
   $('audio track').each((i: any, elem: any) => {
-    paths[$(elem).attr('src')] = elem;
+    paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
   });
 
   Object.keys(paths)

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -111,8 +111,6 @@ export function standardContentManipulations($: any) {
 
   DOM.stripElement($, 'li p');
   DOM.stripElement($, 'p quote');
-  DOM.stripElement($, 'materials material');
-  DOM.stripElement($, 'materials');
 
   $('pullout title').remove();
   DOM.stripElement($, 'pullout');
@@ -131,6 +129,29 @@ export function standardContentManipulations($: any) {
   DOM.rename($, 'extra', 'popup');
 
   handleFormulaMathML($);
+  sideBySideMaterials($);
+}
+
+function sideBySideMaterials($: any) {
+  $('materials material').each((i: any, item: any) => {
+    item.tagName = 'td';
+  });
+  $('materials').each((i: any, item: any) => {
+    item.tagName = 'table';
+    $(item).attr('borderStyle', 'hidden');
+    const orientation = $(item).attr('orient');
+
+    if (
+      orientation === undefined ||
+      orientation === null ||
+      orientation === 'horizontal'
+    ) {
+      $(item).html(`<tr>${$(item).html().trim()}</tr>`);
+    } else {
+      const tr = $('<tr></tr>');
+      $(item).children().wrap(tr);
+    }
+  });
 }
 
 export function handleFormulaMathML($: any) {

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -16,6 +16,30 @@ function getPastDocType(content: string): string {
   return content;
 }
 
+function isBlockElement(name: string) {
+  const blocks = {
+    p: true,
+    img: true,
+    youtube: true,
+    audio: true,
+    codeblock: true,
+    video: true,
+    iframe: true,
+    formula: true,
+    callout: true,
+    h1: true,
+    h2: true,
+    h3: true,
+    h4: true,
+    h5: true,
+    h6: true,
+    ol: true,
+    ul: true,
+    table: true,
+  };
+  return (blocks as any)[name];
+}
+
 function inlineAttrName(attrs: Record<string, unknown>) {
   if (attrs['style'] === 'bold') {
     return 'strong';
@@ -256,6 +280,24 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         }
       };
 
+      const ensureTextDoesNotSurroundBlockElement = (e: string) => {
+        if (tag === e) {
+          if (top() && top().children.length === 3) {
+            const first = top().children[0];
+            const second = top().children[1];
+            const third = top().children[2];
+
+            if (
+              first.text === ' ' &&
+              third.text === ' ' &&
+              isBlockElement(second.type)
+            ) {
+              top().children = [second];
+            }
+          }
+        }
+      };
+
       if (tag !== null) {
         ensureNotEmpty('p');
         ensureNotEmpty('th');
@@ -273,6 +315,8 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         ensureNotEmpty('youtube');
         ensureNotEmpty('audio');
         ensureNotEmpty('li');
+        ensureTextDoesNotSurroundBlockElement('td');
+        ensureTextDoesNotSurroundBlockElement('li');
         elevateCaption('img');
         elevateCaption('iframe');
         elevateCaption('youtube');

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/materials.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/materials.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="materials">
+	<head>
+		<title>
+			Materials tag (side by side layout)
+		</title>
+	</head>
+	<body>
+		<p>
+			The following should render side-by-side, via a table with one row, two columns and hidden borders
+		</p>
+		<materials>
+			<material>
+				<p>
+					Here is a paragraph
+				</p>
+			</material>
+			<material>
+				<image src="../webcontent/polar-bear.jpg">
+					<caption>
+						This is another bear
+					</caption>
+				</image>
+			</material>
+		</materials>
+		<p>
+			The following should render on top of each other, since the materials tag used vertical orientation:
+		</p>
+		<materials orient="vertical">
+			<material>
+				<image src="../webcontent/polar-bear.jpg">
+					<caption>
+						This is a bear
+					</caption>
+				</image>
+			</material>
+			<material>
+				<image src="../webcontent/polar-bear.jpg">
+					<caption>
+						This is another bear
+					</caption>
+				</image>
+			</material>
+		</materials>
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -44,6 +44,9 @@
 					<item id="bca2e8dc245e4ca5889891c18a62d699" scoring_mode="default">
 						<resourceref idref="entities" />
 					</item>
+					<item id="bca2e85e4ca5889891c18a62d699" scoring_mode="default">
+						<resourceref idref="materials" />
+					</item>
 				</module>
 				<module id="variables">
 					<title>


### PR DESCRIPTION
This PR adds support to migrate `<materials>` element, which is used typically to display two things side-by-side.  It migrates materials to a table that is configured to not show it's borders (which Torus doesn't yet support, but will).  It handles both orientations that materials DTD element supports: "horizontal" and "vertical") 

I found and fixed two other issues:
1. If a page contained more than one reference to the same image, only one of the references were properly being updated with the new full URL. 
2. Some page content was leading to generation of `<td>` elements which contained a block element surrounded by two "text" elements that simply contained a single space.  This wasn't breaking anything, as once ingested into Torus these spaces turn into paragraphs. But it was adding unnecesary whitespace.  This specific case is now identified and the extra spaces are removed. 