### PR TITLE
[FEATURE] List styles support

### DIFF
--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/styled_lists.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/styled_lists.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="styled_lists">
+	<head>
+		<title>
+			Styled Lists
+		</title>
+		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+	</head>
+	<body>
+		<p>
+			Here is an unstyled unordered
+		</p>
+		<ul>
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ul>
+		<p>
+			Here are styled unordered lists
+		</p>
+		<p>
+			explicit none
+		</p>
+		<ul style="none">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ul>
+		<p>
+			disc
+		</p>
+		<ul style="disc">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ul>
+		<p>
+			circle
+		</p>
+		<ul style="circle">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ul>
+		<p>
+			square
+		</p>
+		<ul style="square">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ul>
+		<p>
+			Ordered plain
+		</p>
+		<ol>
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			Ordered styled
+		</p>
+		<p>
+			none
+		</p>
+		<ol style="none">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			decimal
+		</p>
+		<ol style="decimal">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			decimal leading zero
+		</p>
+		<ol style="decimal-leading-zero">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+			<li>
+				three
+			</li>
+			<li>
+				four
+			</li>
+			<li>
+				five
+			</li>
+			<li>
+				six
+			</li>
+			<li>
+				seven
+			</li>
+			<li>
+				eight
+			</li>
+			<li>
+				nine
+			</li>
+			<li>
+				ten
+			</li>
+		</ol>
+		<p>
+			lower roman
+		</p>
+		<ol style="lower-roman">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			upper roman
+		</p>
+		<ol style="upper-roman">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			lower latin
+		</p>
+		<ol style="lower-alpha">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			upper alpha
+		</p>
+		<ol style="upper-alpha">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			lower latin
+		</p>
+		<ol style="lower-latin">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+		<p>
+			upper latin
+		</p>
+		<ol style="upper-latin">
+			<li>
+				one
+			</li>
+			<li>
+				two
+			</li>
+		</ol>
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -51,7 +51,7 @@
 						<resourceref idref="composite" />
 					</item>
 					<item id="bca2e88983a62d699" scoring_mode="default">
-						<resourceref idref="video" />
+						<resourceref idref="styled_lists" />
 					</item>
 				</module>
 				<module id="variables">


### PR DESCRIPTION
Given that the legacy `style` attribute for ordered and unordered lists has the same structure in Torus, there is explicit that had to be done to add migration support for list styles.  The PR simply adds a test page demonstrating all list style options. 

List styling already exists on master in Torus