### PR TITLE
[FEATURE] Add video migration support

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -199,6 +199,15 @@ function findFromDOM($: any): Record<string, Array<string>> {
     paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
   });
 
+  $('video').each((i: any, elem: any) => {
+    paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
+  });
+
+  $('video source').each((i: any, elem: any) => {
+    paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
+  });
+
+
   Object.keys(paths)
     .filter((src: string) => !isLocalReference(src))
     .forEach((src: string) => delete paths[src]);

--- a/src/media.ts
+++ b/src/media.ts
@@ -207,7 +207,6 @@ function findFromDOM($: any): Record<string, Array<string>> {
     paths[$(elem).attr('src')] = [elem, ...$(paths[$(elem).attr('src')])];
   });
 
-
   Object.keys(paths)
     .filter((src: string) => !isLocalReference(src))
     .forEach((src: string) => delete paths[src]);

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -143,7 +143,6 @@ export function standardContentManipulations($: any) {
     }
   });
 
-
   DOM.rename($, 'extra', 'popup');
 
   handleFormulaMathML($);

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -132,7 +132,18 @@ export function standardContentManipulations($: any) {
       $(item).attr('id') === undefined ? guid() : $(item).attr('id')
     );
   });
-  DOM.renameAttribute($, 'video source', 'type', 'format');
+  DOM.renameAttribute($, 'video source', 'type', 'contenttype');
+  DOM.renameAttribute($, 'video source', 'src', 'url');
+
+  $('video').each((i: any, item: any) => {
+    const src = $(item).attr('src');
+
+    if (src !== undefined && src !== null && src.trim() !== null) {
+      $(item).html(`<source contenttype="video/mp4" url="${src}"></source>`);
+    }
+  });
+
+
   DOM.rename($, 'extra', 'popup');
 
   handleFormulaMathML($);

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -280,6 +280,19 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         }
       };
 
+      const setVideoAttributes = () => {
+        if (tag === 'video') {
+          top().src = top().children;
+          top().children = [];
+          if (top().width !== undefined) {
+            top().width = parseInt(top().width);
+          }
+          if (top().height !== undefined) {
+            top().height = parseInt(top().height);
+          }
+        }
+      };
+
       const ensureTextDoesNotSurroundBlockElement = (e: string) => {
         if (tag === e) {
           if (top() && top().children.length === 3) {
@@ -326,6 +339,7 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         unescapeFormulaSrc();
         unescapeVariableData();
         setTransformationData();
+        setVideoAttributes();
 
         if (top() && top().children === undefined) {
           top().children = [];

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/video.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/video.xml
@@ -15,5 +15,13 @@
 			</code>
 			attribute:
 		</p>
+		<video src="../webcontent/ammonium.mp4" width="600" height="400" />
+		<p>
+			Here is a video that originally had a multiple sources set via source sub elements:
+		</p>
+		<video width="600" height="400">
+			<source src="../webcontent/sodium_gen.mp4" type="video/mp4" />
+			<source src="../webcontent/sample.webm" type="video/webm" />
+		</video>
 	</body>
 </workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -62,6 +62,9 @@
                     <item id="bca2e88983a62d699" scoring_mode="default">
                         <resourceref idref="styled_lists" />
                     </item>
+                    <item id="bca2e88983a62dd699" scoring_mode="default">
+                      <resourceref idref="video" />
+                    </item>
                 </module>
                 <module id="variables">
                     <title>


### PR DESCRIPTION
Adds migration support for video elements.  

1. Normalizes "src" attribute from either a single, top-level `src` attr or multiple `<source>` children elements.
2. Sets attribute names for contenttype and url attributes
3. Ensures height and width are numbers

