### PR TITLE
[FEATURE] Table migration support

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -155,7 +155,7 @@ function sideBySideMaterials($: any) {
   });
   $('materials').each((i: any, item: any) => {
     item.tagName = 'table';
-    $(item).attr('borderStyle', 'hidden');
+    $(item).attr('border', 'hidden');
     const orientation = $(item).attr('orient');
 
     if (

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -311,6 +311,18 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         }
       };
 
+      const convertTableAttrstoNumbers = () => {
+        if (tag === 'td' || tag === 'th') {
+          
+          if (top().colspan !== undefined) {
+            top().colspan = parseInt(top().colspan);
+          }
+          if (top().rowspan !== undefined) {
+            top().rowspan = parseInt(top().rowspan);
+          }
+        }
+      };
+
       if (tag !== null) {
         ensureNotEmpty('p');
         ensureNotEmpty('th');
@@ -340,6 +352,7 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
         unescapeVariableData();
         setTransformationData();
         setVideoAttributes();
+        convertTableAttrstoNumbers();
 
         if (top() && top().children === undefined) {
           top().children = [];

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -313,7 +313,6 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
 
       const convertTableAttrstoNumbers = () => {
         if (tag === 'td' || tag === 'th') {
-          
           if (top().colspan !== undefined) {
             top().colspan = parseInt(top().colspan);
           }

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/tables.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/tables.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="tables">
+	<head>
+		<title>
+			Table formatting
+		</title>
+		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+	</head>
+	<body>
+		<p>
+			Row style alternating
+		</p>
+		<table rowstyle="alternating"><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></table>
+    <p>
+			Row style plain
+		</p>
+		<table rowstyle="plain"><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></table>
+
+    <p>
+			Cell align right
+		</p>
+		<table><tr><td>This is long</td></tr><tr><td>2</td></tr><tr><td align="right">3</td></tr></table>
+
+    <p>
+			Cell align left
+		</p>
+		<table><tr><td>This is long</td></tr><tr><td>2</td></tr><tr><td align="left">3</td></tr></table>
+
+    <p>
+			Cell align center
+		</p>
+		<table><tr><td>This is long</td></tr><tr><td>2</td></tr><tr><td align="center">3</td></tr></table>
+	
+    <p>
+			Colspan
+		</p>
+		<table>
+      <tr>
+        <th>Month</th>
+        <th>Savings</th>
+      </tr>
+      <tr>
+        <td>January</td>
+        <td>$100</td>
+      </tr>
+      <tr>
+        <td>February</td>
+        <td>$80</td>
+      </tr>
+      <tr>
+        <td colspan="2">Sum: $180</td>
+      </tr>
+    </table>
+
+    <p>row span</p>
+
+    <table>
+      <tr>
+        <th>Month</th>
+        <th>Savings</th>
+        <th>Savings for holiday!</th>
+      </tr>
+      <tr>
+        <td>January</td>
+        <td>$100</td>
+        <td rowspan="2">$50</td>
+      </tr>
+      <tr>
+        <td>February</td>
+        <td>$80</td>
+      </tr>
+    </table>
+
+
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/tables.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/tables.xml
@@ -59,7 +59,7 @@
       <tr>
         <th>Month</th>
         <th>Savings</th>
-        <th>Savings for holiday!</th>
+        <th>Savings for holiday</th>
       </tr>
       <tr>
         <td>January</td>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -65,6 +65,9 @@
                     <item id="bca2e88983a62dd699" scoring_mode="default">
                       <resourceref idref="video" />
                     </item>
+                    <item id="bca2e88983a62dd6ddd99" scoring_mode="default">
+                      <resourceref idref="tables" />
+                    </item>
                 </module>
                 <module id="variables">
                     <title>


### PR DESCRIPTION
Adds table migration support.  The Torus table model is nearly identical to the legacy model, so there was not much to do here.  I needed to convert `rowspan` and `colspan` attributes to numbers, and adjust the `border` Torus property name. 