### PR TITLE
[FEATURE] Handle html5 entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "csv-writer": "^1.6.0",
     "dotenv": "^8.2.0",
     "glob": "^7.1.6",
+    "html-entities": "^2.3.3",
     "jest": "^26.6.3",
     "md5-file": "^5.0.0",
     "mime-types": "^2.1.29",

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -2,6 +2,7 @@
 import * as stream from 'stream';
 import * as fs from 'fs';
 import { decodeEntities } from './common';
+import { decode } from 'html-entities';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const xmlParser = require('./parser');
@@ -137,13 +138,6 @@ export function replaceAll(s: string, t: string, w: string) {
   return s.replace(re, w);
 }
 
-export function replaceUnicodeReferences(s: string): string {
-  return s.replace(/&#x.*?;/g, (matched, _index, _original) => {
-    const parsed = parseInt(matched.substring(3, matched.length - 1), 16);
-    return String.fromCharCode(parsed);
-  });
-}
-
 export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
   const root: any = {};
   root.children = [];
@@ -180,10 +174,11 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
             }
           });
           Object.keys(attrs).forEach((k) => {
-            object[k] =
-              typeof attrs[k] === 'string'
-                ? replaceUnicodeReferences(attrs[k])
-                : attrs[k];
+            object[k] = attrs[k];
+            if (typeof attrs[k] === 'string') {
+              const text = replaceAll(attrs[k], '&amp;', '&');
+              object[k] = decode(text, { level: 'html5' });
+            }
           });
           if (top() !== undefined) {
             top().children.push(object);
@@ -350,13 +345,11 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
     });
 
     parser.on('text', (raw: string) => {
-      let text = replaceAll(raw, '&quot;', '"');
-      text = replaceAll(text, '&amp;', '&');
-      text = replaceAll(text, '&lt;', '<');
-      text = replaceAll(text, '&gt;', '>');
-      text = replaceAll(text, '&apos;', "'");
-
-      text = replaceUnicodeReferences(text);
+      // Cheerio will encode ampersands in non supported XML entities like &times; to be &amp;times;
+      // So to handle these we first decode only ampersands, then feed that result through the
+      // html-entities library's decode to handle all other HTML5 entities.
+      let text = replaceAll(raw, '&amp;', '&');
+      text = decode(text, { level: 'html5' });
 
       const object: any = Object.assign({}, { text }, inlinesToObject(inlines));
       top().children.push(object);

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/entities.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/entities.xml
@@ -8,10 +8,11 @@
 	</head>
 	<body>
 		<p>
-			The following paragraph contains several HTML entities
+			The following paragraphs contains several HTML entities
 		</p>
 		<p>
-			Times: &times; Registered: &reg; Beta: &beta;
+			copyright: &copy; Times: &times; Registered: &reg; Beta: &beta;
 		</p>
+    <p>Less than &lt; greater than &gt; double quote &quot; apos &apos; amp &amp; copyright &#169; delta &#8710;</p>
 	</body>
 </workbook_page>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,6 +2408,11 @@ html-encoding-sniffer@^2.0.1:
   dependencies:
     whatwg-encoding "^1.0.5"
 
+html-entities@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
+  integrity sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
This PR adds more robust support for converting encoded entities from legacy content into their literal character within the Torus JSON data models. 

In theory, only XML entities are supported by the legacy content model (because these files are XML). So that means only named escapes such as `&amp;`, `&apos;` `&lt;` and the decimal and unicode character encodings such as `&#169;`  `&#8710;`.  XML does not support the extended collection of named entities such as `&times;`.  

But, it appears that OLI runtime supports this more complete set of HTML5 entities as `&times;` is found several hundred times through the chemistry courses.  

When mutating an XML document, Cheerio only supports the XML subset, so it thinks that the ampersand in `&times;` needs to be escaped, so it ends up writing it out at `&amp;times;`.  