### PR TITLE
[BUG FIX] Properly handle objectives and skill attachments

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -135,16 +135,32 @@ export function globalizeObjectiveReferences(
   const localToGlobal = resources.reduce((m: any, r: TorusResource) => {
     if (r.type === 'Objective') {
       m[r.id] = `${r.id}-${r.parentId}`;
+      r.id = `${r.id}-${r.parentId}`;
       return m;
     }
     return m;
   }, {});
 
+  const mapArray = (arr: string[]) => arr.map((id) => localToGlobal[id]);
+
   return resources.map((r: TorusResource) => {
-    if (r.type === 'Page') {
-      (r as Page).objectives = (r as Page).objectives.map(
-        (id) => localToGlobal[id]
-      );
+    if (r.type === 'Page' || r.type === 'Objective') {
+      (r as Page).objectives = mapArray((r as Page).objectives);
+      return r;
+    }
+    if (r.type === 'Activity') {
+      if (typeof (r as any).objectives === 'object') {
+        const objectives = Object.keys((r as Activity).objectives).reduce(
+          (m: any, k: any) => {
+            m[k] = mapArray((r as Activity).objectives[k]);
+            return m;
+          },
+          {}
+        );
+
+        (r as Activity).objectives = objectives;
+      }
+
       return r;
     }
     return r;

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -10,6 +10,10 @@ export class Skills extends Resource {
 
   translate(xml: string, $: any): Promise<(TorusResource | string)[]> {
     const objectives: TorusResource[] = [];
+    let parentId = '';
+    $('skills').each((i: any, elem: any) => {
+      parentId = $(elem).attr('id');
+    });
 
     $('skill').each((i: any, elem: any) => {
       const id = $(elem).attr('id');
@@ -18,6 +22,7 @@ export class Skills extends Resource {
       const o = {
         type: 'Objective',
         id,
+        parentId,
         originalFile: '',
         title,
         tags: [],

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-inline-assessment/newca1a54a0f56a4d429f5aff2c515cab08.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-inline-assessment/newca1a54a0f56a4d429f5aff2c515cab08.xml
@@ -22,6 +22,7 @@
                 <choice value="no">Unacceptable</choice>
             </multiple_choice>
             <part id="dc55bc6e18554d3dbdd56017718df7db">
+                <skillref idref="cd6bb81e2b0f4705ac48346f36bfda52"/>
                 <response match="yes" score="0">
                     <feedback>
                         <p id="a2133cdbd21f4f1e84b7906f3e9c3be3">Incorrect; using another student&apos;s password is not acceptable, even if it&apos;s left out in the open. Further, Albert has assumed his girlfriend&apos;s identity by using her account, which is also a violation of the Computing Policy.</p>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-learning_objectives/dd83841bc84045138faf6f3b7868c6dc.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-learning_objectives/dd83841bc84045138faf6f3b7868c6dc.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE objectives PUBLIC "-//Carnegie Mellon University//DTD Learning Objectives 2.0//EN" "http://oli.web.cmu.edu/dtd/oli_learning_objectives_2_0.dtd"><objectives id="dd83841bc84045138faf6f3b7868c6dc"><title>Created In Editor</title><objective id="c47ac29051ed427984e2b6f76d09fa8e">Default objective</objective></objectives>
+<!DOCTYPE objectives PUBLIC "-//Carnegie Mellon University//DTD Learning Objectives 2.0//EN" "http://oli.web.cmu.edu/dtd/oli_learning_objectives_2_0.dtd">
+<objectives id="dd83841bc84045138faf6f3b7868c6dc">
+	<title>
+		Created In Editor
+	</title>
+	<objective id="c47ac29051ed427984e2b6f76d09fa8e">
+		Default objective
+	</objective>
+  <objective_skill idref="c47ac29051ed427984e2b6f76d09fa8e">
+    <skillref idref="cd6bb81e2b0f4705ac48346f36bfda52"/>
+  </objective_skills>
+</objectives>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-skills_model/c04c22b2337f412c8feff2c06e43cef3.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-skills_model/c04c22b2337f412c8feff2c06e43cef3.xml
@@ -1,2 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE skills PUBLIC "-//Carnegie Mellon University//DTD Skills Model 1.0//EN" "http://oli.cmu.edu/dtd/oli_skills_model_1_0.dtd"><skills id="c04c22b2337f412c8feff2c06e43cef3"><title>Created In Editor</title><skill id="cd6bb81e2b0f4705ac48346f36bfda52">Default skill</skill></skills>
+<!DOCTYPE skills PUBLIC "-//Carnegie Mellon University//DTD Skills Model 1.0//EN" "http://oli.cmu.edu/dtd/oli_skills_model_1_0.dtd">
+<skills id="c04c22b2337f412c8feff2c06e43cef3">
+	<title>
+		Created In Editor
+	</title>
+	<skill id="cd6bb81e2b0f4705ac48346f36bfda52">
+		Default skill
+	</skill>
+</skills>


### PR DESCRIPTION
This PR fixes a couple of problems related to ingestion of the learning model.

1. LOs attached to pages were not showing up in Torus.  Root cause was that the id of Objective resource was not being set to the "globalized" id.   That was a single line fix (line 138 of `convert.ts`.
2. After fixed 1 above, the objective hierarchy was not being preserved, and attached skills were not being preserved because those attributes still used the "local" id.  Those now get translated to the global id.

Closes #66 
