### PR TITLE
[BUG FIX] Fixes for data science course

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -406,16 +406,17 @@ export function toActivity(
     p.responses = p.responses.map((r: any) => {
       if (r.showPage !== undefined) {
         const replacement = pageIdIndex.findIndex(
-          (id) => id.length > 1 && id.substring(1) === r.showPage
+          (id) => id.length > 1 && id.at(1) === r.showPage
         );
         if (replacement !== -1) {
           return Object.assign({}, r, { showPage: replacement });
-        } else {
-          console.log(
-            'Warning: could not replace page id with index in branching assessment: ' +
-              legacyId
-          );
+        } else if (parseInt(r.showPage) >= 0) {
+          return Object.assign({}, r, { showPage: parseInt(r.showPage) });
         }
+        console.log(
+          'Warning: could not replace page id with index in branching assessment: ' +
+            legacyId
+        );
       }
       return r;
     });

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -107,6 +107,13 @@ function toActivity(
 ) {
   const id = guid();
 
+  const partIds: any[] = content.authoring.parts.map((p: any) => p.id);
+
+  const objectives = partIds.reduce((m: any, id: any) => {
+    m[id] = [];
+    return m;
+  }, {});
+
   return {
     type: 'Activity',
     id,
@@ -115,7 +122,7 @@ function toActivity(
     tags: [],
     unresolvedReferences: [],
     content,
-    objectives: [],
+    objectives,
     legacyId,
     subType,
     warnings: [],

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -40,10 +40,18 @@ export function eliminateLevel($: any, selector: string) {
 export function flattenResourceRefs($: any) {
   const refs = $('item resourceref');
 
+  const allItems: any = {};
+
   refs.each((i: any, elem: any) => {
     const id = $(elem).attr('idref');
-    $(elem).parent().replaceWith(`<item idref="${id}"></item>`);
+    if (allItems[id] === undefined) {
+      allItems[id] = true;
+      $(elem).parent().replaceWith(`<item idref="${id}"></item>`);
+    } else {
+      $(elem).parent().replaceWith(`<duplicate></duplicate>`);
+    }
   });
+  $('duplicate').remove();
 }
 
 // Utility function that allows determining whether an instance of a mixed type element (e.g. formula) is


### PR DESCRIPTION
Fixes three things for the data science course:

1. Makes the page index determination for branching assessment more robust.  The DS course had page ids in two cases that were unexpected.   The first was of the form: `p3_xxxxx`.  It was assumed previously that page ids were of the form `p3`.    The second case was just a completely bad page id, with no leading `p`.  
2. Sets the `objectives` field for superactivities to be an object with keys of the part ids to empty arrays.
3. Eliminates any resource that appears more than once in the course hierarchy.  The case we will run into a lot with Echo courses is the now infamous `placehodlerid` page. 