### PR TITLE
[FEATURE] handle sections with purpose attribute

### DIFF
--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -26,7 +26,6 @@ export class WorkbookPage extends Resource {
   restructure($: any): any {
     standardContentManipulations($);
 
-    DOM.flattenNestedSections($);
     liftTitle($);
     DOM.rename($, 'wb\\:inline', 'activity_placeholder');
     DOM.rename($, 'inline', 'activity_placeholder');

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -3,15 +3,22 @@
 import * as cheerio from 'cheerio';
 import * as fs from 'fs';
 
-function flattenSection($: any, selector: string, tag: string) {
+function flattenSection($: cheerio.CheerioAPI, selector: string, tag: string) {
   const triple = $(selector);
 
-  triple.each((i: any, elem: any) => {
+  triple.each((i: any, elem: cheerio.TagElement) => {
     const text = $(elem).children('title').html();
 
     $(elem).children('title').replaceWith(`<${tag}>${text}</${tag}>`);
     $(elem).children('body').replaceWith($(elem).children('body').children());
-    $(elem).replaceWith($(elem).children());
+
+    const purpose = $(elem).attr('purpose');
+    if (purpose) {
+      // replace the section element with a group placeholder
+      elem.tagName = 'group';
+    } else {
+      $(elem).replaceWith($(elem).children());
+    }
   });
 }
 

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/sections.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/sections.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="sections">
+    <head>
+        <title>Sections</title>
+        <objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+    </head>
+    <body>
+        <p>
+            <em style="italic">The following series of activities incorporates the concepts from this module into a
+            real-world scenario.</em>
+        </p>
+        <section purpose="checkpoint">
+            <title>Question 1</title>
+            <body>
+                <wb:inline idref="weak_titration_lbd"/>
+            </body>
+        </section>
+    </body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -101,6 +101,9 @@
                     <item id="bca2a2dad6aasdfasdddd99" scoring_mode="default">
                       <resourceref idref="conjugation" />
                     </item>
+                    <item id="bca2a2dad6aasdfasddde00" scoring_mode="default">
+                      <resourceref idref="sections" />
+                    </item>
                 </module>
                 <module id="variables">
                     <title>

--- a/test/resources/workbook-test.ts
+++ b/test/resources/workbook-test.ts
@@ -152,4 +152,68 @@ describe('convert workbook', () => {
       },
     ]);
   });
+
+  it('should translate a section with purpose to a group with purpose', async () => {
+    const file =
+      'test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/sections.xml';
+    const mediaSummary: Media.MediaSummary = {
+      mediaItems: {},
+      missing: [],
+      urlPrefix: '',
+      flattenedNames: {},
+    };
+
+    const converted = await convert(mediaSummary, file, false);
+
+    expect(converted).toContainEqual(
+      expect.objectContaining({
+        type: 'Page',
+        id: 'sections',
+        content: expect.objectContaining({
+          model: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'content',
+              id: expect.any(String),
+              children: [
+                {
+                  type: 'p',
+                  children: [
+                    { text: ' ' },
+                    {
+                      text: 'The following series of activities incorporates the concepts from this module into a real-world scenario.',
+                      em: true,
+                    },
+                    { text: ' ' },
+                  ],
+                },
+              ],
+            }),
+            expect.objectContaining({
+              type: 'group',
+              children: [
+                expect.objectContaining({
+                  type: 'content',
+                  id: expect.any(String),
+                  children: [
+                    {
+                      type: 'h1',
+                      children: [{ text: 'Question 1' }],
+                    },
+                  ],
+                }),
+                {
+                  type: 'activity_placeholder',
+                  children: [],
+                  idref: 'weak_titration_lbd',
+                },
+              ],
+              purpose: 'checkpoint',
+              layout: 'vertical',
+              id: expect.any(String),
+            }),
+          ]),
+        }),
+      })
+    );
+  });
 });


### PR DESCRIPTION
Adds support for sections with a purpose set by converting the section into a group with the same purpose and adding the title and content to the group.

<img width="1355" alt="Screen Shot 2022-09-28 at 5 41 46 PM" src="https://user-images.githubusercontent.com/6248894/192893898-57519df6-10a8-402f-a269-4ff978c237ff.png">
