### PR TITLE
[ENHANCEMENT] fail for unsupported elements

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -62,7 +62,34 @@ export function addWarning(
   resource.warnings.push({ idref, description });
 }
 
+export function failIfPresent($: any, items: string[]) {
+  items.forEach((e: string) => {
+    $(e).each((_i: any, _item: any) => {
+      console.log(`unsupported element [${e}] detected, exiting`);
+      process.exit(1);
+    });
+  });
+}
+
+export function failIfHasValue(
+  $: any,
+  selector: string,
+  attr: string,
+  value: string
+) {
+  $(selector).each((_i: any, item: any) => {
+    if ($(item).attr(attr) === value) {
+      console.log(
+        `unsupported element attribute value [${selector} ${attr} ${value}] detected, exiting`
+      );
+      process.exit(1);
+    }
+  });
+}
+
 export function standardContentManipulations($: any) {
+  failIfPresent($, ['ipa', 'bdo']);
+
   DOM.unwrapInlinedMedia($, 'video');
   DOM.unwrapInlinedMedia($, 'audio');
   DOM.unwrapInlinedMedia($, 'youtube');
@@ -113,6 +140,11 @@ export function standardContentManipulations($: any) {
   // Certain elements are not currently (and some may never be) supported
   // in Torus, so we remove them.  In this respect, OLI course conversion
   // is lossy wrt specific element constructs.
+  $('question_bank_ref').remove();
+  $('wb\\:manual').remove();
+  $('wb\\:path').remove();
+  $('testandconfigure').remove();
+  $('theme').remove();
   $('popout').remove();
   $('sym').remove();
   $('applet').remove();

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -12,6 +12,8 @@ import {
   standardContentManipulations,
   processCodeblock,
   processVariables,
+  failIfPresent,
+  failIfHasValue,
 } from './common';
 import {
   findCustomTag,
@@ -556,6 +558,11 @@ export class Formative extends Resource {
   }
 
   translate($: any): Promise<(TorusResource | string)[]> {
+    failIfPresent($, ['response_mult', 'no_response', 'grading_criteria']);
+    failIfHasValue($, 'content', 'available', 'instructor_only');
+    failIfHasValue($, 'content', 'available', 'feedback_only');
+    failIfHasValue($, 'content', 'available', 'never');
+
     performRestructure($);
     const xml = $.html();
     return new Promise((resolve, _reject) => {

--- a/src/resources/organization.ts
+++ b/src/resources/organization.ts
@@ -28,7 +28,19 @@ function flattenOrganization($: any) {
 export class Organization extends Resource {
   restructure($: any): any {
     failIfHasValue($, 'sequence', 'audience', 'instructor');
-    failIfPresent($, ['include', 'unordered', 'supplement', 'labels']);
+    failIfPresent($, ['include', 'unordered', 'supplement']);
+    const labels = $('labels').first();
+    if (labels !== undefined && labels !== null) {
+      if (
+        $(labels).attr('sequence') !== 'Sequence' ||
+        $(labels).attr('unit') !== 'Unit' ||
+        $(labels).attr('module') !== 'Module' ||
+        $(labels).attr('section') !== 'Section'
+      ) {
+        console.log('organization contains custom labels: [' + this.file + ']');
+        process.exit(1);
+      }
+    }
 
     DOM.flattenResourceRefs($);
     DOM.mergeTitles($);

--- a/src/resources/organization.ts
+++ b/src/resources/organization.ts
@@ -3,6 +3,7 @@ import { ItemReference } from 'src/utils/common';
 import * as Histogram from 'src/utils/histogram';
 import * as DOM from 'src/utils/dom';
 import * as XML from 'src/utils/xml';
+import { failIfHasValue, failIfPresent } from './common';
 
 import { Resource, TorusResource, Hierarchy, Summary } from './resource';
 
@@ -26,6 +27,9 @@ function flattenOrganization($: any) {
 
 export class Organization extends Resource {
   restructure($: any): any {
+    failIfHasValue($, 'sequence', 'audience', 'instructor');
+    failIfPresent($, ['include', 'unordered', 'supplement', 'labels']);
+
     DOM.flattenResourceRefs($);
     DOM.mergeTitles($);
     removeSequences($);

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -6,6 +6,7 @@ import {
   processCodeblock,
   wrapContentInGroup,
   flagStandardContentWarnigns,
+  failIfPresent,
 } from './common';
 import * as DOM from 'src/utils/dom';
 import * as XML from 'src/utils/xml';
@@ -24,6 +25,13 @@ export class WorkbookPage extends Resource {
   }
 
   restructure($: any): any {
+    failIfPresent($, [
+      'multipanel',
+      'wb\\:xref',
+      'xref',
+      'objective',
+      'dependency',
+    ]);
     standardContentManipulations($);
 
     liftTitle($);

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/dialog.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/dialog.xml
@@ -7,6 +7,9 @@
 		</title>
 	</head>
 	<body>
+
+    <p>This paragraph contains <foreign>quelque mots</foreign> in a different language.</p>
+
 	 <dialog>
       <title>Dialog title</title>
       <audio src="../webcontent/sample-3s.mp3"/>


### PR DESCRIPTION
This PR causes the digest tool fail when it encounters certain blacklisted elements and/or attribute values.  These represent things that the tool and Torus do not yet support. 