### PR TITLE
[ENHANCEMENT] Add validation utility, adjust purpose types, fix label detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "ts-node -r tsconfig-paths/register src/index.ts",
+    "validate": "ts-node -r tsconfig-paths/register src/validate.ts",
     "test": "jest -c jest.config.js",
     "test:watch": "jest --watch -c jest.config.js",
     "lint": "npx eslint src test",
@@ -27,6 +28,7 @@
     "glob": "^7.1.6",
     "html-entities": "^2.3.3",
     "jest": "^26.6.3",
+    "jsonschema": "^1.4.1",
     "md5-file": "^5.0.0",
     "mime-types": "^2.1.29",
     "node-xml-stream-parser": "^1.0.12",

--- a/src/resources/organization.ts
+++ b/src/resources/organization.ts
@@ -29,8 +29,7 @@ export class Organization extends Resource {
   restructure($: any): any {
     failIfHasValue($, 'sequence', 'audience', 'instructor');
     failIfPresent($, ['include', 'unordered', 'supplement']);
-    const labels = $('labels').first();
-    if (labels !== undefined && labels !== null) {
+    $('labels').each((i: any, labels: any) => {
       if (
         $(labels).attr('sequence') !== 'Sequence' ||
         $(labels).attr('unit') !== 'Unit' ||
@@ -40,7 +39,7 @@ export class Organization extends Resource {
         console.log('organization contains custom labels: [' + this.file + ']');
         process.exit(1);
       }
-    }
+    });
 
     DOM.flattenResourceRefs($);
     DOM.mergeTitles($);

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -14,6 +14,21 @@ import { convertImageCodingActivities } from './image';
 import { maybe } from 'tsmonad';
 import { convertBibliographyEntries } from './bibentry';
 
+const validPurposes = {
+  none: true,
+  checkpoint: true,
+  didigetthis: true,
+  labactivity: true,
+  learnbydoing: true,
+  learnmore: true,
+  manystudentswonder: true,
+  myresponse: true,
+  quiz: true,
+  simulation: true,
+  walkthrough: true,
+  example: true,
+};
+
 function liftTitle($: any) {
   $('workbook_page').attr('title', $('head title').text());
   $('head').children().remove('title');
@@ -69,6 +84,14 @@ export class WorkbookPage extends Resource {
 
     $('activity').each((i: any, elem: any) => {
       const idref = $(elem).attr('idref');
+      const purpose = $(elem).attr('purpose');
+      if (
+        purpose !== null &&
+        purpose !== undefined &&
+        (validPurposes as any)[purpose] === undefined
+      ) {
+        $(elem).attr('purpose', 'none');
+      }
       page.unresolvedReferences.push(idref);
     });
 

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -236,16 +236,29 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
       };
 
       const elevatePopoverContent = () => {
-        if (tag === 'popup' && top().children.length === 2) {
+        if (tag === 'popup') {
           const anchor = getOneOfType(top().children, 'anchor');
           const meaning = getOneOfType(top().children, 'meaning');
+          const pronunciation = getOneOfType(top().children, 'pronunciation');
+          const translation = getOneOfType(top().children, 'translation');
 
-          if (anchor !== null && meaning !== null) {
-            const material = getOneOfType(meaning.children, 'material');
-
+          if (anchor !== null) {
             top().children = anchor.children;
-            top().content = material.children;
             top().trigger = 'hover';
+
+            if (pronunciation !== null) {
+              top().audioSrc = pronunciation.src;
+              top().audioType = pronunciation.contenttype;
+            }
+
+            if (meaning !== null) {
+              const material = getOneOfType(meaning.children, 'material');
+              top().content = material.children;
+            } else if (translation !== null) {
+              top().content = translation.children;
+            } else {
+              top().content = [{ type: 'text', text: ' ' }];
+            }
           }
         }
       };

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,58 @@
+import { Validator, Schema } from 'jsonschema';
+import * as glob from 'glob';
+import * as fs from 'fs';
+
+const v = new Validator();
+let count = 0;
+const args = process.argv.slice(2);
+
+loadSchemas(args[0]).then((pageSchema: Schema) => {
+  validatePages(pageSchema);
+});
+
+function loadSchemas(dir: string) {
+  return new Promise((resolve, _reject) => {
+    let pageSchema: Schema | null = null;
+    glob(`${dir}/*.json`, {}, (err: any, files: any) => {
+      files.forEach((f: any) => {
+        const json = readJSON(f);
+        if (f.indexOf('page-content-basic.schema.json') !== -1) {
+          pageSchema = json;
+        }
+        v.addSchema(json, json.id);
+      });
+      resolve(pageSchema as unknown as Schema);
+    });
+  });
+}
+
+function validatePages(pageSchema: Schema) {
+  glob(`./out/*.json`, {}, (err: any, files: any) => {
+    files.forEach((f: any) => maybeValidate(f, pageSchema));
+  });
+}
+
+function maybeValidate(file: string, pageSchema: Schema) {
+  const json = readJSON(file);
+  if (json.type === 'Page') {
+    validate(json, pageSchema);
+  }
+}
+
+function validate(content: Record<string, unknown>, pageSchema: Schema) {
+  (content.content as any).version = '0.1.0';
+  const result = v.validate(content.content, pageSchema as unknown as Schema);
+  count++;
+  if (!result.valid) {
+    console.log('Failed: ' + content.id);
+    console.log(result);
+  }
+  if (count % 10 === 0) {
+    console.log(count);
+  }
+}
+
+function readJSON(file: string) {
+  const content = fs.readFileSync(file);
+  return JSON.parse(content.toString());
+}

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/extra.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/extra.xml
@@ -8,6 +8,22 @@
 		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
 	</head>
 	<body>
+    <p>There should be one on the following paragrap:</p>
+    <p>Tu vas faire ta <extra>
+      <anchor>propre</anchor>
+      <translation>own</translation>
+   </extra> lessive, je présume.</p>
+   <p>And another one, with an audio clip:</p>
+    <p>Tu vas faire ta <extra>
+      <anchor>Il téléphone à moi.</anchor>
+      <pronunciation src="..//webcontent/F1L10s228.mp3" type="audio/mp3"/>
+   </extra> lessive, je présume.</p>
+   <p>And another one, with an audio and translation:</p>
+    <p>Tu vas faire ta <extra>
+      <anchor>Il téléphone à moi.</anchor>
+      <pronunciation src="..//webcontent/F1L10s228.mp3" type="audio/mp3"/>
+      <translation>He telephones me</translation>
+   </extra> lessive, je présume.</p>
 		<p>
 			There should be two popups in the following paragraphs, enabled via hover over the words
 			<em>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,6 +3232,11 @@ json5@2.x, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonschema@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
+  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
This PR includes two fixes and two enhancements:

1. Fix: Adjust how the `<labels>` element from organizations was being detected. The initial impl was improperly reporting that an org that didn't include the labels element was using custom labels. 
2. Fix: Ensure that purpose types align with Torus purpose types for `page_link` instances, if not, set it to `none`.
3. Enhancement: Add a utility script to allow validation of all pages.  Usage `npm run validate <the directory to torus schemas>`.  This will validate all pages found in JSON files within the `./out` directory. 
4. Enhancement: Adds support for the `<extra><anchor/><pronunciation/><translation/></extra>` variant of the `<extra>` tag that is used by modern language courses to show a popup with an optional audio clip that auto-plays. 