### PR TITLE
[ENHANCEMENT] remove no_response

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -532,6 +532,7 @@ export function performRestructure($: any) {
   standardContentManipulations($);
 
   DOM.rename($, 'question body', 'stem');
+  DOM.remove($, 'no_response');
   DOM.eliminateLevel($, 'section');
 
   migrateVariables($);
@@ -558,7 +559,7 @@ export class Formative extends Resource {
   }
 
   translate($: any): Promise<(TorusResource | string)[]> {
-    failIfPresent($, ['response_mult', 'no_response', 'grading_criteria']);
+    failIfPresent($, ['response_mult', 'grading_criteria']);
     failIfHasValue($, 'content', 'available', 'instructor_only');
     failIfHasValue($, 'content', 'available', 'feedback_only');
     failIfHasValue($, 'content', 'available', 'never');

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/newc72f87db5a5543b5ae8582d2d4cd34a7.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/newc72f87db5a5543b5ae8582d2d4cd34a7.xml
@@ -32,6 +32,9 @@
                         <p id="f277ed5de9c949138801d812b4a9cc3a">Correct; this is a pretty clear violation of the policy, including using another person&apos;s account and impersonating another individual.</p>
                     </feedback>
                 </response>
+                <no_response score="0">
+                  <feedback>You did not answer this question.</feedback>
+               </no_response>
             </part>
         </multiple_choice>
         <fill_in_the_blank id="add_subtratAndmult_div_pool_v1" grading="automatic">


### PR DESCRIPTION
Torus does not support custom feedback for when a student does not answer a question in a summative context.  