### PR TITLE
[ENHANCEMENT] strip heigh width from responsively rendered media elements

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -168,6 +168,11 @@ export function standardContentManipulations($: any) {
   handleAlternate($, 'iframe');
   handleAlternate($, 'youtube');
 
+  // iframe and youtube are both designed to scale responsively within Torus, so
+  // we need to strip out height and width attrs if they exist
+  stripMediaSizing($, 'iframe');
+  stripMediaSizing($, 'youtube');
+
   DOM.stripElement($, 'p ol');
   DOM.stripElement($, 'p ul');
   DOM.stripElement($, 'p li');
@@ -248,6 +253,13 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'li formula', 'formula_inline');
   DOM.rename($, 'li callback', 'callback_inline');
+}
+
+function stripMediaSizing($: any, selector: string) {
+  $(selector).each((i: any, item: any) => {
+    $(item).removeAttr('height');
+    $(item).removeAttr('width');
+  });
 }
 
 function handleConjugations($: any) {

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/media.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/media.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="media">
+	<head>
+		<title>
+			Iframe with width
+		</title>
+		<objref idref="c47ac29051ed427984e2b6f76d09fa8e" />
+	</head>
+	<body>
+		<p>
+			The following should have had its width and height stripped out
+		</p>
+    <iframe src="https://www.google.com" width="400px" height="300px"/>
+		
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -104,6 +104,9 @@
                     <item id="bca2a2dad6aasdfasddde00" scoring_mode="default">
                       <resourceref idref="sections" />
                     </item>
+                    <item id="bca2a2dad6asasdfasddaade00" scoring_mode="default">
+                      <resourceref idref="media" />
+                    </item>
                 </module>
                 <module id="variables">
                     <title>


### PR DESCRIPTION
This change adds an explicit removal of the `width` and `height` attributes for youtube and iframe elements.  Leaving them in place can end up rendering them in Torus, which interfers with the intent to render them in a responsive manner. 

https://eliterate.atlassian.net/browse/MER-1489