### PR TITLE
[FEATURE] All ingested multiinput use submitPerPart

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -187,12 +187,6 @@ export function standardContentManipulations($: any) {
   DOM.stripElement($, 'p p');
   DOM.stripElement($, 'p p');
 
-  $('dl title').remove();
-  $('dl dt').each((i: any, elem: any) => {
-    const term = $(elem).text();
-    $(elem).attr('term', term);
-  });
-
   DOM.stripElement($, 'li p');
   DOM.rename($, 'li img', 'img_inline');
   DOM.stripElement($, 'p quote');

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -49,6 +49,7 @@ export function buildMulti(
     stem: buildStem(question, inputs, skipInputRefValidation),
     choices: allChoices,
     inputs,
+    submitPerPart: true,
     authoring: {
       targeted: allTargeted,
       parts: torusParts,


### PR DESCRIPTION
Sets the new `submitPerPart` field to be `true` for all multiinput questions. 

Also ajdusts the definition list migration for new `<dl>` tagset