### PR TITLE
[BUG FIX] handle dl tagset correctly when there are not titles

### DIFF
--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -469,9 +469,9 @@ export function toJSON(xml: string, preserveMap = {}): Promise<unknown> {
           const title = getOneOfType(top().children, 'title');
           if (title !== null && title !== undefined) {
             top().title = title.children;
-            top().items = top().children.filter((c: any) => c.type !== 'title');
-            top().children = [];
           }
+          top().items = top().children.filter((c: any) => c.type !== 'title');
+          top().children = [];
         }
       };
 


### PR DESCRIPTION
Minor adjustment so that `<dl>` elements without titles are processed. 