### PR TITLE
[BUG FIX] handle image tags that should be inline image tags

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -133,6 +133,13 @@ export function standardContentManipulations($: any) {
   // a closer mapping to the correct rendering.
   DOM.rename($, 'p img', 'img_inline');
   DOM.rename($, 'a img', 'img_inline');
+
+  $('img').each((i: any, item: any) => {
+    if (DOM.isInlineElement($, item)) {
+      item.tagName = 'img_inline';
+    }
+  });
+
   // Inline images should technically be valid in any Slate model element
   // that supports inline elements, but we're only explicitly handling
   // converting images in paragraphs and links (anchors).

--- a/test/resources/common-test.ts
+++ b/test/resources/common-test.ts
@@ -47,7 +47,7 @@ describe('cdata and codeblocks', () => {
     standardContentManipulations($);
 
     const result: any = await toJSON($.xml(), projectSummary);
-    const img = result.children[0];
+    const img = result.children[0].children[0];
     expect(img.type).toBe('img');
   });
 

--- a/test/resources/common-test.ts
+++ b/test/resources/common-test.ts
@@ -37,7 +37,7 @@ describe('cdata and codeblocks', () => {
   });
 
   test('should convert root images to block imgs', async () => {
-    const content = '<image src="../webcontent/proof_prem.gif"/>';
+    const content = '<root><image src="../webcontent/proof_prem.gif"/></root>';
 
     const $ = cheerio.load(content, {
       normalizeWhitespace: true,


### PR DESCRIPTION
Similar to `formula`, `image` is a mixed tag in that it can appear inline and as block.  We have to handle detecting when there is an image tag (already renamed here to `img`) that sits at the top level, but whose sibliings are text.  Basically, if this image really needs to be treated as an inline element, then we rename it to `img_line`.  Same solution that we have for `formula`.  

This fixes problems where a stem of a question looks like this:

```
<stem>
Take a look at the image below:
<image src="..."/>
</stem>
```

The first line of the stem gets stripped out if we leave this image as a block image, so we must convert it to inline.

Generate a chemistry course digest and look at the page "Bohr Model of the Atom Calculations", the last inline has two questions.  One of them exhibits the above question stem structure. 