### PR TITLE
[ENHANCEMENT] change active to enabled

### DIFF
--- a/src/resources/discussion.ts
+++ b/src/resources/discussion.ts
@@ -118,7 +118,7 @@ export class Discussion extends Resource {
         page.title = r.children[0].title;
 
         // Override the default collab space configuration
-        page.collabSpace.status = 'active';
+        page.collabSpace.status = 'enabled';
         page.collabSpace.auto_accept = readBooleanParameter(
           $,
           'options',


### PR DESCRIPTION
This switches the collab space config use of "active" to "enabled" to keep it in lock step with the values that Torus actually uses. 