### PR TITLE
Fix ctat import

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -340,7 +340,7 @@ export function findInPackage(
   if (!fs.existsSync(decodedPath)) {
     if (dir.endsWith('content/')) return absolutePath;
     const dirArray: string[] = dir.split('/');
-    dirArray.pop();
+    if (dirArray[dirArray.length - 1] === '') dirArray.pop();
     dirArray.pop();
     dir = dirArray.join('/') + '/';
     return findInPackage(dir, reference, path.resolve(dir, reference));

--- a/src/media.ts
+++ b/src/media.ts
@@ -95,7 +95,6 @@ export function transformToFlatDirectory(
           );
         } else if ($(elem)[0].name === 'dataset') {
           const pkg = $(elem).attr('package');
-
           $(elem).replaceWith(
             `<dataset package="${pkg}">${url.slice(
               url.lastIndexOf('media/') + 6

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -41,7 +41,11 @@ export class Superactivity extends Resource {
         if (!defaults) {
           resolve(['']);
         } else {
-          if (file.includes('x-oli-embed-activity-highstakes') || navigable) {
+          if (
+            file.includes('x-oli-embed-activity-highstakes') ||
+            file.includes('x-cmu-ctat-tutor2') ||
+            navigable
+          ) {
             const activity = toActivity(
               toActivityModel(defaults.base, defaults.src, title, xml),
               guid(),
@@ -173,13 +177,13 @@ function determineActivityDefaults(
     case 'ctat':
       if (file.indexOf('x-cmu-ctat-tutor2') !== -1) {
         return {
-          subType: 'oli_ctat2',
+          subType: 'oli_embedded',
           base: 'ctat2',
           src: 'tutor.html',
         };
       }
       return {
-        subType: 'oli_ctat',
+        subType: 'oli_embedded',
         base: 'ctat',
         src: 'tutor.html',
       };


### PR DESCRIPTION
This PR adds support for CTAT in the course digest tool. It makes use of the existing torus OLI embed custom activity instead of introducing a new custom activity type. 

A CTAT shortcoming that this digest is unable to overcome is how to handle file references within indirect activity support files. Many activities depend on support files such as HTML, CSS, Javascript, brd, etc, that may internally reference other files, usually in a relative fashion. This is particularly problematic given the digest tools file flattening when uploaded into AWS. Extra work will be required to resolve these issues per activity after course import.