### PR TITLE
[BUGFIX] Preserve text alongside block content in stems

### DIFF
--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -66,6 +66,8 @@ export function wrapText(children: any) {
         c.text !== undefined ? { type: 'p', children: [{ text: c.text }] } : c
       );
   }
+
+  return children;
 }
 
 export function buildStem(question: any) {

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -54,7 +54,7 @@ export function isBlankText(e: any): boolean {
 }
 
 export function collectTextsIntoParagraphs(children: any) {
-  let result = [];
+  const result = [];
   let successiveTexts: any[] = [];
   children.forEach((c: any) => {
     if (c.text !== undefined) {

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-inline-assessment/scientific_notation.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-inline-assessment/scientific_notation.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Inline Assessment MathML 1.4//EN" "http://oli.web.cmu.edu/dtd/oli_inline_assessment_mathml_1_4.dtd">
+<?xml-stylesheet type="text/css" href="http://oli.web.cmu.edu/authoring/oxy-author/oli_inline_assessment_1_1.css"?>
+<assessment id="scientific_notation">
+    <title>tutor</title>
+    <page>
+        
+        <question id="q1">
+            <body>To be sure you understand this process, enter 6.022&times;10<sup>23</sup> in the input box below. 
+                Be sure to use the process as described above.
+                <p><input_ref input="q1numeric"/> </p>
+            </body>
+            <numeric id="q1numeric" size="small"></numeric>
+            <part>
+                <response match="6.022e23" score="10" input="q1numeric">
+                    <feedback>Correct. This is the way to enter scientific notation into numeric input answer boxes 
+                    throughout the course.</feedback>
+                </response>
+                <response match="*" input="q1numeric">
+                    <feedback>Incorrect. Enter 6.022e23 into the input box.  </feedback>
+                </response>
+               
+            </part>
+        </question>
+    </page>
+    
+</assessment>
+
+

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/loosetext.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-workbook_page/loosetext.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/" xmlns:theme="http://oli.web.cmu.edu/presentation/" xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="loosetext">
+	<head>
+		<title>
+			Loose Text in Question Stems
+		</title>
+	</head>
+	<body>
+		<p>
+	This tests proper handling of loose text elements included alongside other elements in question stems.
+		</p>
+		<inline idref="scientific_notation" />
+	</body>
+</workbook_page>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -1,150 +1,157 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE organization PUBLIC "-//Carnegie Mellon University//DTD Content Organization Simple 2.3//EN" "http://oli.web.cmu.edu/dtd/oli_content_organization_simple_2_3.dtd">
 <organization id="migration-4sdfykby-1.0_default" version="1.0">
-    <title>
+  <title>
 		Default Organization
 	</title>
-    <description>
+  <description>
 		Sample organization included with the OLI project template.
 	</description>
-    <audience>
+  <audience>
 		This organization is intended as an example for OLI content authors.
 	</audience>
-    <pref:preference_values xmlns:pref="http://oli.web.cmu.edu/preferences/">
-      <pref:preference_value fixed="false" value="excel" preference="statistics.package" />
-    </pref:preference_values>
-    <labels sequence="Sequence" unit="Unit" module="Module" section="Section" />
-    <sequences>
-        <sequence id="part1" category="content" audience="all">
-            <title>
+  <pref:preference_values xmlns:pref="http://oli.web.cmu.edu/preferences/">
+    <pref:preference_value fixed="false" value="excel" preference="statistics.package"/>
+  </pref:preference_values>
+  <labels sequence="Sequence" unit="Unit" module="Module" section="Section"/>
+  <sequences>
+    <sequence id="part1" category="content" audience="all">
+      <title>
 				Project Template
 			</title>
-            <unit id="pre_student_survey">
-                <title>Student Feedback</title>
-                <module id="pre_survey">
-                    <title>Pre-Course Student Expectations</title>
-                    <item>
-                        <resourceref idref="pre_course_survey"/>
-                    </item>
-                </module>
-            </unit>
-            <unit id="lesson1">
-                <title>
+      <unit id="pre_student_survey">
+        <title>Student Feedback</title>
+        <module id="pre_survey">
+          <title>Pre-Course Student Expectations</title>
+          <item>
+            <resourceref idref="pre_course_survey"/>
+          </item>
+        </module>
+      </unit>
+      <unit id="lesson1">
+        <title>
 					Lesson 1
 				</title>
-                <module id="introduction">
-                    <title>
+        <module id="introduction">
+          <title>
 						Introduction
 					</title>
-                    <item id="bca2e8dcf45e4ca5889891c18a62d648" scoring_mode="default">
-                        <resourceref idref="welcome" />
-                    </item>
-                    <item id="ebe32e4f2039442896f67b64a54acd0d" scoring_mode="default">
-                        <resourceref idref="newe6ddd6fec8f54749a037ef13abd8df93" />
-                    </item>
-                    <item id="ebe32e4f2039442896f67b64a54acd0e" scoring_mode="default">
-                        <resourceref idref="newc72f87db5a5543b5ae8582d2d4cd34a7" />
-                    </item>
-                </module>
-                <module id="br">
-                  <title>
+          <item id="bca2e8dcf45e4ca5889891c18a62d648" scoring_mode="default">
+            <resourceref idref="welcome"/>
+          </item>
+          <item id="ebe32e4f2039442896f67b64a54acd0d" scoring_mode="default">
+            <resourceref idref="newe6ddd6fec8f54749a037ef13abd8df93"/>
+          </item>
+          <item id="ebe32e4f2039442896f67b64a54acd0e" scoring_mode="default">
+            <resourceref idref="newc72f87db5a5543b5ae8582d2d4cd34a7"/>
+          </item>
+        </module>
+        <module id="br">
+          <title>
           Branching assessments
         </title>
-                  <item id="bca2e8dcf45e89891c18a62d648" scoring_mode="default">
-                      <resourceref idref="branching_page" />
-                  </item>
-                 
-              </module>
-                <module id="corecomponents">
-                    <title>
+          <item id="bca2e8dcf45e89891c18a62d648" scoring_mode="default">
+            <resourceref idref="branching_page"/>
+          </item>
+        </module>
+        <module id="corecomponents">
+          <title>
 						Core Page Components
 					</title>
-                    <item id="bca2e8dcsssca5889891c18a62d699" scoring_mode="default">
-                        <resourceref idref="submit_and_compare_page" />
-                    </item>
-                    <item id="bca2e8dcf45e4ca5889891c18a62d699" scoring_mode="default">
-                        <resourceref idref="extra" />
-                    </item>
-                    <item id="bca45e4ca5889891c12d699" scoring_mode="default">
-                      <resourceref idref="images" />
-                  </item>
-                    <item id="bca2e8dcf45e4ca5889891c18a62d699" scoring_mode="default">
-                        <resourceref idref="mathml" />
-                    </item>
-                    <item id="bca2e8dc245e4ca5889891c18a62d699" scoring_mode="default">
-                        <resourceref idref="entities" />
-                    </item>
-                    <item id="bca2e85e4ca5889891c18a62d699" scoring_mode="default">
-                        <resourceref idref="materials" />
-                    </item>
-                    <item id="bca2e889891c18a62d699" scoring_mode="default">
-                        <resourceref idref="composite" />
-                    </item>
-                    <item id="bca2e88983a62d699" scoring_mode="default">
-                        <resourceref idref="styled_lists" />
-                    </item>
-                    <item id="bca2e88983a62dd699" scoring_mode="default">
-                      <resourceref idref="video" />
-                    </item>
-                    <item id="bca2e88983a62dd6ddd99" scoring_mode="default">
-                      <resourceref idref="tables" />
-                    </item>
-                    <item id="bca2e88dad983a62dd6ddd99" scoring_mode="default">
-                      <resourceref idref="inquiry" />
-                    </item>
-                    <item id="bca2s99" scoring_mode="default">
-                      <resourceref idref="definitions" />
-                    </item>
-                    <item id="bca2a2dd6ddd99" scoring_mode="default">
-                      <resourceref idref="figures" />
-                    </item>
-                    <item id="bca2a2dad6ddd99" scoring_mode="default">
-                      <resourceref idref="dialog" />
-                    </item>
-                    <item id="bca2a2dad6aasdfasdddd99" scoring_mode="default">
-                      <resourceref idref="conjugation" />
-                    </item>
-                    <item id="bca2a2dad6aasdfasddde00" scoring_mode="default">
-                      <resourceref idref="sections" />
-                    </item>
-                    <item id="bca2a2dad6asasdfasddaade00" scoring_mode="default">
-                      <resourceref idref="media" />
-                    </item>
-                    <item id="bca2a2daad6aasasdfasddaade00" scoring_mode="default">
-                      <resourceref idref="command" />
-                    </item>
-                    <item id="bca2aa2daad6aasasdfasddaade00" scoring_mode="default">
-                      <resourceref idref="definition_list" />
-                    </item>
-                    <item id="45375887E0B04DF7A98BF5DA2D17455B" scoring_mode="default">
-                      <resourceref idref="alternatives" />
-                    </item>
-                </module>
-                <module id="variables">
-                    <title>
+          <item id="bca2e8dcsssca5889891c18a62d699" scoring_mode="default">
+            <resourceref idref="submit_and_compare_page"/>
+          </item>
+          <item id="bca2e8dcf45e4ca5889891c18a62d699" scoring_mode="default">
+            <resourceref idref="extra"/>
+          </item>
+          <item id="bca45e4ca5889891c12d699" scoring_mode="default">
+            <resourceref idref="images"/>
+          </item>
+          <item id="bca2e8dcf45e4ca5889891c18a62d699" scoring_mode="default">
+            <resourceref idref="mathml"/>
+          </item>
+          <item id="bca2e8dc245e4ca5889891c18a62d699" scoring_mode="default">
+            <resourceref idref="entities"/>
+          </item>
+          <item id="bca2e85e4ca5889891c18a62d699" scoring_mode="default">
+            <resourceref idref="materials"/>
+          </item>
+          <item id="bca2e889891c18a62d699" scoring_mode="default">
+            <resourceref idref="composite"/>
+          </item>
+          <item id="bca2e88983a62d699" scoring_mode="default">
+            <resourceref idref="styled_lists"/>
+          </item>
+          <item id="bca2e88983a62dd699" scoring_mode="default">
+            <resourceref idref="video"/>
+          </item>
+          <item id="bca2e88983a62dd6ddd99" scoring_mode="default">
+            <resourceref idref="tables"/>
+          </item>
+          <item id="bca2e88dad983a62dd6ddd99" scoring_mode="default">
+            <resourceref idref="inquiry"/>
+          </item>
+          <item id="bca2s99" scoring_mode="default">
+            <resourceref idref="definitions"/>
+          </item>
+          <item id="bca2a2dd6ddd99" scoring_mode="default">
+            <resourceref idref="figures"/>
+          </item>
+          <item id="bca2a2dad6ddd99" scoring_mode="default">
+            <resourceref idref="dialog"/>
+          </item>
+          <item id="bca2a2dad6aasdfasdddd99" scoring_mode="default">
+            <resourceref idref="conjugation"/>
+          </item>
+          <item id="bca2a2dad6aasdfasddde00" scoring_mode="default">
+            <resourceref idref="sections"/>
+          </item>
+          <item id="bca2a2dad6asasdfasddaade00" scoring_mode="default">
+            <resourceref idref="media"/>
+          </item>
+          <item id="bca2a2daad6aasasdfasddaade00" scoring_mode="default">
+            <resourceref idref="command"/>
+          </item>
+          <item id="bca2aa2daad6aasasdfasddaade00" scoring_mode="default">
+            <resourceref idref="definition_list"/>
+          </item>
+          <item id="45375887E0B04DF7A98BF5DA2D17455B" scoring_mode="default">
+            <resourceref idref="alternatives"/>
+          </item>
+        </module>
+        <module id="variables">
+          <title>
 						Dynamic Questions
 					</title>
-                    <item id="bca2e8dcf45e4ca588989dc18a62d29" scoring_mode="default">
-                        <resourceref idref="assessment_with_selection" />
-                    </item>
-                </module>
-                <module id="dnd">
-                    <title>
+          <item id="bca2e8dcf45e4ca588989dc18a62d29" scoring_mode="default">
+            <resourceref idref="assessment_with_selection"/>
+          </item>
+        </module>
+        <module id="dnd">
+          <title>
 						Drag and Drop Questions
 					</title>
-					<item id="bca2e8dcf45e4ca5832d29" scoring_mode="default">
-						<resourceref idref="customdnd" />
-					</item>
-				</module>
-				<module id="super">
-					<title>
+          <item id="bca2e8dcf45e4ca5832d29" scoring_mode="default">
+            <resourceref idref="customdnd"/>
+          </item>
+        </module>
+        <module id="super">
+          <title>
 						Super Activities
 					</title>
-					<item id="bca2e8dcf45e4ca5836d29" scoring_mode="default">
-						<resourceref idref="embed_super" />
-					</item>
-				</module>
-			</unit>
-		</sequence>
-	</sequences>
+          <item id="bca2e8dcf45e4ca5836d29" scoring_mode="default">
+            <resourceref idref="embed_super"/>
+          </item>
+        </module>
+        <module id="bugfixes">
+          <title>
+					Bug Fixes	
+					</title>
+          <item id="55375887E0B04DF7A98BF5DA2D17455C" scoring_mode="default">
+            <resourceref idref="loosetext"/>
+          </item>
+        </module>
+      </unit>
+    </sequence>
+  </sequences>
 </organization>


### PR DESCRIPTION
Fix for MER-1744. Changed to preserve non-empty "loose" text pieces found alongside block elements in question stems, as occurs frequently in Chemistry, wrapping them in paragraph tags. Tested by ingesting Chem1 locally and comparing a sample of assessment questions to version on Tokomak. Looks to work without breaking any existing questions.

In one case, seeing the newly ingested text exposed a *different* issue -- subscript tag causes a paragraph break rather than being converted to inline style, badly breaking up CO<sub>2</sub>.  [Update: now corrected]