### PR TITLE
command line convenience tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ yarn install
 npm run start -- --operation convert --inputDir <course input dir>
 ```
 
-Optionally, you can specify a specific output directory. Defaults to `./out`
+Optionally, you can specify a specific output directory. Defaults to `<inputDir>-out`
 ```
 npm run start -- --operation convert --inputDir <course input dir> --outputDir ./out
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ interface CmdOptions extends commandLineArgs.CommandLineOptions {
   specificOrg: string;
   specificOrgId: string;
   mediaUrlPrefix: string;
-  quiet: string;
+  quiet: boolean;
 }
 
 interface ConvertedResults {

--- a/test/convert-test.ts
+++ b/test/convert-test.ts
@@ -37,6 +37,7 @@ it('should convert example course to valid course digest', async () => {
     specificOrgId,
     downloadRemote: false,
     mediaUrlPrefix: 'https://example-url-prefix',
+    quiet: false,
   });
 
   expect(projectSummary.getAlternativesGroupsJSON()).toEqual({
@@ -108,6 +109,7 @@ it('should convert content with purpose to groups', async () => {
     specificOrgId,
     downloadRemote: false,
     mediaUrlPrefix: 'https://torus-media-dev.s3.amazonaws.com/media',
+    quiet: false,
   });
 
   mediaItems.forEach((mediaItem) => {


### PR DESCRIPTION
Minor tweaks for more convenient command line. Primarily for developer use when repeatedly testing:

--inputDir may be abbreviated -i; arg may be relative path.

--outputDir may be abbreviated -o

--operation may be omitted, defaults to convert

--quiet, -q [new option] suppresses prompts and does not zip or upload

Also CHANGES output naming:
     outputDir if omitted defaults to ${inputDir}-out
     zip file named as ${outputDir}.zip

Together this makes it possible to type simply
`npm run start -- -i courseDir`
to convert a course, leaving courseDir-out and optionally courseDir-out.zip file alongside courseDir in directory tree and
`npm run start -- -qi courseDir`
to convert only without prompting for input.

