### PR TITLE
[BUGFIX] handle special chars in regex match; support case-insensitive matches

### DIFF
--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -313,7 +313,6 @@ export function matchToRule(match: string, input: any, type: any) {
     // handle as regexp w/case-insensitive option prefix
     const pat = isRegExp(m) ? getRegExp(m) : escapeRegExp(m);
     m = `/(?i)${pat}/`;
-    console.log(`case-insensitive ${match} => ${m}`);
   }
 
   const toMatch = isRegExp(m) ? getRegExp(m) : m;


### PR DESCRIPTION
Fixes MER-1745, MER-1746.  Adjusts regex matching for answer patterns for text input items to escape special characters where needed and to support case-insensitive matching where that option is set. 

This also attempts to change the translation of case-_sensitive_ literal string matches into "equals" rules, rather than "like" rules, to avoid escaping metacharacters where not necessary. However, currently the equals operator does not show up on the torus answer authoring interface (MER-1762). These present as "contains" rules on the interface. However, they seem to work as desired.

Case-sensitive matches are rare in the chemistry course, used in only one extra practice on elements. All other text matches in that course are left as case-insensitive.