### PR TITLE
Use iequals op for case-insensitive string match

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -25,6 +25,7 @@ import * as DOM from 'src/utils/dom';
 import * as XML from 'src/utils/xml';
 import * as Common from './questions/common';
 import { ProjectSummary } from 'src/project';
+import { convertCatchAll } from './questions/common';
 
 function usesSimpleModel(responses: any[]) {
   return Common.hasCatchAll(responses) && responses.length <= 2;
@@ -49,8 +50,8 @@ function buildMCQPart(question: any) {
     const item: any = {
       id: guid(),
       score: r.score === undefined ? 0 : parseFloat(r.score),
-      rule: `input like {${replaceAll(r.match, '\\*', '.*')}}`,
-      legacyMatch: replaceAll(r.match, '\\*', '.*'),
+      rule: `input like {${convertCatchAll(r.match)}}`,
+      legacyMatch: convertCatchAll(r.match),
       feedback: {
         id: guid(),
         content: Common.getFeedbackModel(r),

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -31,6 +31,10 @@ export function convertAutoGenResponses(model: any) {
   }
 }
 
+export function convertCatchAll(match: string): string {
+  return match === '*' ? '.*' : match;
+}
+
 export function hasCatchAll(responses: any[]) {
   return responses.some((r) => r.match === 'input like {.*}');
 }
@@ -228,7 +232,7 @@ export function buildTextPart(id: string, question: any) {
   return {
     id: '1',
     responses: responses.map((r: any) => {
-      const cleanedMatch = replaceAll(r.match, '\\*', '.*');
+      const cleanedMatch = convertCatchAll(r.match);
       const item: any = {
         id: guid(),
         score: r.score === undefined ? 0 : parseFloat(r.score),

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -1,5 +1,5 @@
 import { maybe } from 'tsmonad';
-import { guid, replaceAll } from 'src/utils/common';
+import { guid } from 'src/utils/common';
 import * as XML from '../../utils/xml';
 
 export function getChild(collection: any, named: string) {

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -3,6 +3,7 @@
 import { guid, replaceAll } from 'src/utils/common';
 
 import * as Common from './common';
+import { convertCatchAll } from './common';
 
 // a JSON representation of the Formative Legacy model of this question type
 export function buildMulti(
@@ -333,7 +334,7 @@ export function buildInputPart(
   return {
     id,
     responses: responses.map((r: any) => {
-      const cleanedMatch = r.match === '*' ? '.*' : r.match;
+      const cleanedMatch = convertCatchAll(r.match);
       const item: any = {
         id: guid(),
         score: r.score === undefined ? 0 : parseFloat(r.score),

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -94,6 +94,7 @@ export function visit(
         Object.keys(attrs).forEach((k) => {
           if (
             typeof (attrs as any)[k] === 'string' &&
+            k !== 'match' &&
             (attrs as any)[k].endsWith('/')
           ) {
             (attrs as any)[k] = (attrs as any)[k].substr(
@@ -184,10 +185,12 @@ export function toJSON(
 
           Object.keys(attrs).forEach((k) => {
             if (k !== '___selfClosing___' && (attrs as any)[k].endsWith('/')) {
-              (attrs as any)[k] = (attrs as any)[k].substr(
-                0,
-                (attrs as any)[k].length - 1
-              );
+              if (k !== 'match') {
+                (attrs as any)[k] = (attrs as any)[k].substr(
+                  0,
+                  (attrs as any)[k].length - 1
+                );
+              }
             }
           });
           Object.keys(attrs).forEach((k) => {


### PR DESCRIPTION
This changes the converter output for case-insensitive string answer matches to use the new iequals matching rule, rather than mapping to a regular expression match (which does not do a full string match).  Torus should be updated with #3275 addressing MER-1765 before this version of the digest tool is used.