### PR TITLE
MER-1748 escape $ in bib entries for citation-js parser

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
       "javascript",
       "typescript"
   ],
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   // Runs Prettier, then ESLint
   "editor.codeActionsOnSave": [
     "source.formatDocument",

--- a/src/resources/bibentry.ts
+++ b/src/resources/bibentry.ts
@@ -33,7 +33,8 @@ export function convertBibliographyEntries(
       method: 'text',
     });
 
-    const data = new Cite(bibtexVal);
+    // citation-js parser treats $ (used in some titles) as math delimiter, so escape it.
+    const data = new Cite(bibtexVal.replaceAll('$', '\\$'));
     const cslData = data.get({
       format: 'string',
       type: 'json',


### PR DESCRIPTION
$ is used in some article titles, but the citation-js component we are using to parse citations apparently treats it as a latex math delimiter. Work around this by escaping all $'s in bibliography entry to \$ before handing to the citation-js parser. 

