### PR TITLE
[BUGFIX] Fix conversion of audio elements [MER-1799]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -256,6 +256,8 @@ export function standardContentManipulations($: any) {
   DOM.renameAttribute($, 'video source', 'type', 'contenttype');
   DOM.renameAttribute($, 'video source', 'src', 'url');
 
+  DOM.renameAttribute($, 'audio', 'type', 'audioType');
+
   DOM.rename($, 'extra', 'popup');
 
   handleFormulaMathML($);


### PR DESCRIPTION
Fix conversion of. audio elements in content by renaming "type" attribute (containing mimeType, e.g. 'audio/mpeg') to "audioType" to avoid conflict with major element "type", which should remain simply 'audio'. Similar to what is done for video elements. Was being done but only for certain specific-context audio elements. 