### PR TITLE
[BUGFIX] Fix error converting inline images [MER-1843]

### DIFF
--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -548,6 +548,7 @@ export function toJSON(
         ensureTextDoesNotSurroundBlockElement('dt');
         ensureTextDoesNotSurroundBlockElement('li');
         elevateCaption('img');
+        elevateCaption('img_inline');
         elevateCaption('figure');
         elevateCaption('iframe');
         elevateCaption('youtube');


### PR DESCRIPTION
Make sure to call elevateCaption on img_inline elements just as for img elements to prevent prevent childless block image element resulting in case of inline image with empty caption.

(Process here is hairy. ensureNonEmpty is called earlier, but the existence of a caption child -- even though an empty one -- at that stage prevents this call to ensureNotEmpty from doing anything. elevateCaption fixes this up later for images. But this was not being called on img_inline elements). 