### PR TITLE
[BUGFIX] correct choiceID in multi-input targeted feedback map [MER-1877]

### DIFF
--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -166,7 +166,8 @@ function produceTorusEquivalents(
 
     if (!(part.responses as Array<any>).some((r) => r.legacyMatch === '.*')) {
       part.responses.forEach((r: any) => {
-        targeted.push([[r.legacyMatch], r.id]);
+        // must adjust to match part-qualified choiceIds we generate
+        targeted.push([[part.id + '_' + r.legacyMatch], r.id]);
       });
     }
   }


### PR DESCRIPTION
Fixes conversion of targeted feedback for multi-input questions with dropdown parts. In this case conversion generates new part-qualified IDs for the choices. For example if part1 has choices w/ids A and B, new choice ids are part1-A and part1-B. But this change was not being applied when converting the targeted feedback map, which maps choiceIDs to responses. 