### PR TITLE
[BUGFIX] Fix conversion of ordering questions [MER-1801]

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -155,7 +155,7 @@ function buildOrderingPart(question: any) {
       const id = guid();
       const cleanedMatch = convertCatchAll(r.match);
       // change legacy a,b,c to torus {a b c}. No effect on catchAll so safe on all matches
-      const torusMatch = replaceAll(cleanedMatch, ',', ' ');
+      const torusMatch = cleanedMatch.split(/\s*,\s*/).join(' ');
       const item: any = {
         id,
         score: r.score === undefined ? 0 : parseInt(r.score),
@@ -296,7 +296,7 @@ function ordering(question: any) {
     (r: any) => r.score !== undefined && r.score !== 0
   )[0];
 
-  const correctIds = correctResponse.legacyRule.split(',');
+  const correctIds = correctResponse.legacyRule.split(/\s*,\s*/);
   (model.authoring.correct as any).push(correctIds);
   (model.authoring.correct as any).push(correctResponse.id);
 

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -153,11 +153,15 @@ function buildOrderingPart(question: any) {
     id: Common.getPartIds(question)[0],
     responses: responses.map((r: any) => {
       const id = guid();
+      const cleanedMatch = convertCatchAll(r.match);
+      // change legacy a,b,c to torus {a b c}. No effect on catchAll so safe on all matches
+      const torusMatch = replaceAll(cleanedMatch, ',', ' ');
       const item: any = {
         id,
         score: r.score === undefined ? 0 : parseInt(r.score),
-        rule: `input like {${replaceAll(r.match, '\\*', '.*')}}`,
-        legacyRule: replaceAll(r.match, '\\*', '.*'),
+
+        rule: `input like {${torusMatch}}`,
+        legacyRule: cleanedMatch,
         feedback: {
           id: guid(),
           content: Common.getFeedbackModel(r),
@@ -291,6 +295,7 @@ function ordering(question: any) {
   const correctResponse = model.authoring.parts[0].responses.filter(
     (r: any) => r.score !== undefined && r.score !== 0
   )[0];
+
   const correctIds = correctResponse.legacyRule.split(',');
   (model.authoring.correct as any).push(correctIds);
   (model.authoring.correct as any).push(correctResponse.id);

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -1,6 +1,6 @@
 import { visit } from 'src/utils/xml';
 import * as Histogram from 'src/utils/histogram';
-import { guid, ItemReference, replaceAll } from 'src/utils/common';
+import { guid, ItemReference } from 'src/utils/common';
 import {
   Resource,
   TorusResource,


### PR DESCRIPTION
Correct response's match rule was not being converted correctly on ordering questions. Legacy notation uses comma-separated list of choice ids. This converts them to torus' space-separated form. 

Also allows white space in legacy list because apparently legacy tolerated this (seen in one case).