### PR TITLE
[ENHANCEMENT] include color map for custom ordering choice colors [MER-1803]

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -276,7 +276,8 @@ function ordering(question: any) {
   );
   const transformationsArray =
     transformationElement === undefined ? [] : [transformationElement];
-  const model = {
+
+  const model: any = {
     stem: Common.buildStem(question),
     choices: Common.buildChoices(question, 'ordering'),
     authoring: {
@@ -291,6 +292,14 @@ function ordering(question: any) {
       targeted: [],
     },
   };
+
+  // ordering choices may specify a custom color. Collect any into choiceID=>colorName map
+  let colorMap: Map<string, string> = new Map();
+  Common.getChild(question.children, 'ordering')
+    .children.filter((c: any) => c.color !== undefined)
+    .forEach((c: any) => colorMap.set(c.value, c.color));
+  // Include optional map if custom color found, serialized as array of [id, color] pairs
+  if (colorMap.size > 0) model.choiceColors = [...colorMap];
 
   const correctResponse = model.authoring.parts[0].responses.filter(
     (r: any) => r.score !== undefined && r.score !== 0

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -294,7 +294,7 @@ function ordering(question: any) {
   };
 
   // ordering choices may specify a custom color. Collect any into choiceID=>colorName map
-  let colorMap: Map<string, string> = new Map();
+  const colorMap: Map<string, string> = new Map();
   Common.getChild(question.children, 'ordering')
     .children.filter((c: any) => c.color !== undefined)
     .forEach((c: any) => colorMap.set(c.value, c.color));


### PR DESCRIPTION
Within ordering questions only, choices may include a custom color attribute, setting the background color. French uses this to color code choices by speaker in questions asking to order bits of dialog. This has the converter collect custom ordering choice colors and add them to the ordering question model in a new "choiceColors" attribute representing a map from choiceIDs to color namesas an array of [choiceID, colorName] pairs. Intention is for this to be added as an optional element in the torus model, so need not be included where custom colors not used. 