### PR TITLE
[BUGFIX] prevent crash on multi-select hotspot [MER-1929]

### DIFF
--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -1,6 +1,7 @@
 import { guid } from 'src/utils/common';
 import * as Common from './common';
 import { matchListRule } from './rules';
+import { convertCatchAll } from './common';
 
 // Helper. Assumes a correct ID is given
 interface Identifiable {
@@ -115,7 +116,8 @@ export function buildCATAPart(question: any) {
       const item: any = {
         id,
         score: r.score === undefined ? 0 : parseInt(r.score),
-        rule: r.match,
+        rule: convertCatchAll(r.match),
+        legacyMatch: convertCatchAll(r.match),
         name: r.name,
         feedback: {
           id: guid(),


### PR DESCRIPTION
Error was causing crash on conversion of multiple-selection image-hotspot question. Common buildCataPart routine being used to build part in this case did not fill in legacyMatch attribute later accessed by question conversion. 