### PR TITLE
Warn on response_mult [MER-1942]

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -435,8 +435,9 @@ export function toActivity(
   // provisional title, may be adjusted by caller w/more context
   activity.title = activity.id;
 
-  /* const result = Common.getDescendants(question.children, 'response_mult');
-  if (result.length > 0) console.log('q uses response_mult: ' + q.id); */
+  const result = Common.getDescendants(question.children, 'response_mult');
+  if (result.length > 0)
+    console.log(question.id + ' unsupported element: response_mult ');
 
   const [content, imageReferences] = buildModel(
     subType,


### PR DESCRIPTION
Logic and Proofs course evaded the unsupported element check for response_mult because their uses are in pools, and due to bug check wasn't being applied to pools. This is an ad hoc provisional change to address this, but by giving a warning message if it is found. Doesn't quit so work can still be done on other areas of the course. Warning includes question id so can be grepped to tally uses. 