### PR TITLE
[BUGFIX]  Prevent stripping whitespace within popup anchor text [MER-1797]

### DIFF
--- a/src/resources/discussion.ts
+++ b/src/resources/discussion.ts
@@ -105,6 +105,8 @@ export class Discussion extends Resource {
         li: true,
         td: true,
         material: true,
+        anchor: true,
+        translation: true,
         dt: true,
         dd: true,
       }).then((r: any) => {

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -651,6 +651,8 @@ export class Formative extends Resource {
         feedback: true,
         explanation: true,
         material: true,
+        anchor: true,
+        translation: true,
         dt: true,
         dd: true,
       }).then((r: any) => {

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -435,8 +435,9 @@ export function toActivity(
   // provisional title, may be adjusted by caller w/more context
   activity.title = activity.id;
 
-  /* const result = Common.getDescendants(question.children, 'response_mult');
-  if (result.length > 0) console.log('q uses response_mult: ' + q.id); */
+  const result = Common.getDescendants(question.children, 'response_mult');
+  if (result.length > 0)
+    console.log(question.id + ' unsupported element: response_mult ');
 
   const [content, imageReferences] = buildModel(
     subType,

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -183,6 +183,8 @@ export class WorkbookPage extends Resource {
         li: true,
         td: true,
         material: true,
+        anchor: true,
+        translation: true,
         dt: true,
         dd: true,
       }).then((r: any) => {


### PR DESCRIPTION
Adds `<anchor> ` to the list of tags passed to the toJSON parser for which whitespace must be preserved. `<Anchor>` is used for the text within `<extra>` definition translated to popup in torus. Example below. While some semantic elements of this type wrap their content in `<material>`, which was being treated properly, this is not always necessary. Any tag that can contain text content beyond a plain text string must be included, so also included `<translation>`.

```
<extra>
  <anchor>Je <em style="emphasis">ne</em> sais <em style="emphasis">plus</em>.</anchor>
  <translation>I don’t know anymore.</translation>
</extra>
```


