### PR TITLE
Avoid including null objectives for dangling skillrefs

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -291,7 +291,10 @@ export function globalizeObjectiveReferences(
 
   return resources.map((r: TorusResource) => {
     if (r.type === 'Page' || r.type === 'Objective') {
-      (r as Page).objectives = mapArray((r as Page).objectives);
+      // dangling skillrefs will have no id mapping: remove from list.
+      (r as Page).objectives = mapArray((r as Page).objectives).filter(
+        (id) => id != undefined
+      );
       return r;
     }
     if (r.type === 'Activity') {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -291,7 +291,8 @@ export function globalizeObjectiveReferences(
 
   return resources.map((r: TorusResource) => {
     if (r.type === 'Page' || r.type === 'Objective') {
-      // dangling skillrefs will have no id mapping: remove from list.
+      // When used to fix up Objective resource, sub-objectives are skill ids.
+      // Dangling skillrefs will have no id mapping: remove from list.
       (r as Page).objectives = mapArray((r as Page).objectives).filter(
         (id) => id != undefined
       );


### PR DESCRIPTION
Dangling skillrefs within objectives were leading to nulls in the objectives list, causing problems for torus objectives display observed on KTH ONE-LEARNS migration. This silently filters them from the relevant lists.