### PR TITLE
Don't treat basepath asset as media file ref

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -433,7 +433,10 @@ function findFromDOM(
   });
 
   $('asset').each((i: any, elem: any) => {
-    if ($(elem).text().includes('webcontent')) {
+    if (
+      $(elem).text().includes('webcontent') &&
+      $(elem).attr('name') !== 'basepath'
+    ) {
       paths[$(elem).text()] = [elem, ...$(paths[$(elem).text()])];
     }
   });


### PR DESCRIPTION
Captivate superactivity can specify a "basepath" asset which should not be treated as a reference to a media file as other assets are. It does reference a webcontent path, but to a directory, causing digest-tool crash on trying to read this as a file for inclusion in media library.