### PR TITLE
[BUGFIX] [MER-1899] make specificOrg param work

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -228,11 +228,11 @@ export function updateDerivativeReferences(
 export function createProducts(
   resources: TorusResource[],
   orgPaths: string[],
-  baseOrgPath: string,
+  baseOrg: string,
   projectSummary: ProjectSummary
 ): Promise<TorusResource[]> {
   const exceptPrimaryOrg = orgPaths
-    .filter((p) => p !== baseOrgPath && !p.endsWith(baseOrgPath))
+    .filter((p) => !p.endsWith(`${baseOrg}/organization.xml`))
     .map((path) => {
       const o = new Organization(path, false);
       const $ = DOM.read(path, { normalizeWhitespace: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,8 +36,7 @@ const optionDefinitions = [
   { name: 'mediaManifest', type: String, alias: 'm' },
   { name: 'outputDir', type: String, alias: 'o' },
   { name: 'inputDir', type: String, alias: 'i' },
-  { name: 'specificOrg', type: String },
-  { name: 'specificOrgId', type: String },
+  { name: 'specificOrg', type: String, alias: 'g' },
   { name: 'mediaUrlPrefix', type: String, alias: 'p' },
   { name: 'spreadsheetPath', type: String, alias: 's' },
   { name: 'svnRoot', type: String },
@@ -74,7 +73,7 @@ function validateArgs(options: CmdOptions) {
       options.outputDir = `${options.inputDir}-out`;
     }
     if (options.specificOrg === undefined) {
-      options.specificOrg = `${options.inputDir}/organizations/default/organization.xml`;
+      options.specificOrg = 'default';
     }
     if (options.svnRoot === undefined) {
       options.svnRoot = '';
@@ -109,7 +108,7 @@ function summaryAction(options: CmdOptions) {
 
   return executeSerially([
     () => mapResources(packageDirectory),
-    () => collectOrgItemReferences(packageDirectory),
+    () => collectOrgItemReferences(packageDirectory, options.specificOrg),
   ])
     .then((results: any) =>
       processResources(
@@ -165,7 +164,7 @@ export function convertAction(options: CmdOptions): Promise<ConvertedResults> {
 
   return executeSerially([
     () => mapResources(packageDirectory),
-    () => collectOrgItemReferences(packageDirectory),
+    () => collectOrgItemReferences(packageDirectory, specificOrg),
     () => getLearningObjectiveIds(packageDirectory),
     () => getSkillIds(packageDirectory),
   ]).then((results: any) => {
@@ -197,7 +196,8 @@ export function convertAction(options: CmdOptions): Promise<ConvertedResults> {
       mediaSummary
     );
 
-    return Convert.convert(projectSummary, specificOrg, false).then(
+    const specificOrgPath = `${packageDirectory}/organizations/${specificOrg}/organization.xml`;
+    return Convert.convert(projectSummary, specificOrgPath, false).then(
       (results) => {
         const hierarchy = results[0] as Resources.TorusResource;
 
@@ -322,7 +322,7 @@ function helpAction() {
   console.log('-------------------------------------\n');
   console.log('Usage:\n');
   console.log(
-    'npm run start -- [convert] --inputDir <course package dir> --mediaUrlPrefix <public S3 media url prefix>  [--outputDir <outdir dir>] [--specificOrg <org path>]'
+    'npm run start -- [convert] --inputDir <course package dir> --mediaUrlPrefix <public S3 media url prefix>  [--outputDir <outdir dir>] [--specificOrg <org folder name>]'
   );
   console.log(
     'npm run start -- upload --mediaManifest <outputDir/_media-manifest.json>'

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,6 @@ interface CmdOptions extends commandLineArgs.CommandLineOptions {
   svnRoot: string;
   downloadRemote: boolean;
   specificOrg: string;
-  specificOrgId: string;
   mediaUrlPrefix: string;
   quiet: boolean;
 }

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -42,16 +42,19 @@ export function mapResourcesInNamedDirectory(
   });
 }
 
-function determineDefaultOrgId(packageDirectory: string) {
+function determineOrgId(packageDirectory: string, specificOrg: string) {
   const $ = DOM.read(
-    `${packageDirectory}/organizations/default/organization.xml`
+    `${packageDirectory}/organizations/${specificOrg}/organization.xml`
   );
   return $('organization').first().attr('id');
 }
 
-export function collectOrgItemReferences(packageDirectory: string) {
+export function collectOrgItemReferences(
+  packageDirectory: string,
+  specificOrg: string
+) {
   const files = glob.sync(`${packageDirectory}/**/*.xml`, {});
-  const id = determineDefaultOrgId(packageDirectory);
+  const id = determineOrgId(packageDirectory, specificOrg);
 
   const filesById = files.reduce((m: any, f) => {
     const lastPart = f.substring(f.lastIndexOf('/') + 1);

--- a/test/convert-test.ts
+++ b/test/convert-test.ts
@@ -17,15 +17,8 @@ it('should convert example course to valid course digest', async () => {
     'migration-4sdfykby_v_1_0-echo'
   );
 
-  const specificOrgId = 'migration-4sdfykby-1.0_default';
-  const specificOrg = path.join(
-    __dirname,
-    'course_packages',
-    'migration-4sdfykby_v_1_0-echo',
-    'organizations',
-    'default',
-    'organization.xml'
-  );
+  // const specificOrgId = 'migration-4sdfykby-1.0_default';
+  const specificOrg = 'default';
 
   const { projectSummary, hierarchy } = await convertAction({
     operation: 'convert',
@@ -34,7 +27,6 @@ it('should convert example course to valid course digest', async () => {
     svnRoot: '',
     inputDir: packageDirectory,
     specificOrg,
-    specificOrgId,
     downloadRemote: false,
     mediaUrlPrefix: 'https://example-url-prefix',
     quiet: false,
@@ -90,15 +82,8 @@ it('should convert content with purpose to groups', async () => {
     'migration-4sdfykby_v_1_0-echo'
   );
 
-  const specificOrgId = 'migration-4sdfykby-1.0_default';
-  const specificOrg = path.join(
-    __dirname,
-    'course_packages',
-    'migration-4sdfykby_v_1_0-echo',
-    'organizations',
-    'default',
-    'organization.xml'
-  );
+  // const specificOrgId = 'migration-4sdfykby-1.0_default';
+  const specificOrg = 'default';
   const { finalResources, mediaItems } = await convertAction({
     operation: 'convert',
     mediaManifest: '',
@@ -106,7 +91,6 @@ it('should convert content with purpose to groups', async () => {
     svnRoot: '',
     inputDir: packageDirectory,
     specificOrg,
-    specificOrgId,
     downloadRemote: false,
     mediaUrlPrefix: 'https://torus-media-dev.s3.amazonaws.com/media',
     quiet: false,


### PR DESCRIPTION
Fix MER-1899, a hurdle for stats conversion, by making the specificOrg command line parameter actually get used as described. For simpler command line, change to make it take org folder name rather than full path. Org path derived as `${projectDir}/organizations/${specificOrg}/organization.xml `

Allow -g abbreviation for -orG (-o already used for outputDir). Remove never-used specificOrgId parameter. 