### PR TITLE
[ENHANCEMENT] Handle blocks within list items [MER-2057]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -2,6 +2,7 @@ import { ItemReference, guid } from 'src/utils/common';
 import * as Histogram from 'src/utils/histogram';
 import * as DOM from 'src/utils/dom';
 import { TorusResource } from './resource';
+import * as Common from './questions/common';
 
 export interface HasReferences {
   found: () => ItemReference[];
@@ -211,9 +212,10 @@ export function standardContentManipulations($: any) {
   DOM.stripElement($, 'p p');
   DOM.stripElement($, 'p p');
 
-  DOM.stripElement($, 'li p');
+  // Change to allow block elements within list items
+  // DOM.stripElement($, 'li p');
 
-  DOM.rename($, 'li img', 'img_inline');
+  // DOM.rename($, 'li img', 'img_inline');
   DOM.stripElement($, 'p quote');
 
   $('p table').remove();
@@ -650,4 +652,15 @@ export function wrapContentInSurvey(content: any[]) {
     id: guid(),
     children: content,
   };
+}
+
+// Normalize all LIs below given rootObj that contain block items such as images to wrap
+// text in paragraphs for Slate editor requirements. Operates on javascript content objects
+// after JSONification from XML DOM elements to make use of existing wrapLooseText
+export function fixListItemsWithBlocks(rootObj: any) {
+  const listItems: any[] = Common.getDescendants(rootObj.children, 'li');
+  listItems.forEach((a: any) => {
+    // wrapLooseText only modifies if block elements alongside texts
+    a.children = Common.wrapLooseText(a.children);
+  });
 }

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -214,8 +214,8 @@ export function standardContentManipulations($: any) {
 
   // Change to allow block elements within list items
   // DOM.stripElement($, 'li p');
-
   // DOM.rename($, 'li img', 'img_inline');
+
   DOM.stripElement($, 'p quote');
 
   $('p table').remove();
@@ -659,8 +659,8 @@ export function wrapContentInSurvey(content: any[]) {
 // after JSONification from XML DOM elements to make use of existing wrapLooseText
 export function fixListItemsWithBlocks(rootObj: any) {
   const listItems: any[] = Common.getDescendants(rootObj.children, 'li');
-  listItems.forEach((a: any) => {
+  listItems.forEach((li: any) => {
     // wrapLooseText only modifies if block elements alongside texts
-    a.children = Common.wrapLooseText(a.children);
+    li.children = Common.wrapLooseText(li.children);
   });
 }

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -112,7 +112,7 @@ export function collectTextsIntoParagraphs(children: any) {
   return result;
 }
 
-export function wrapLooseText(children: any) {
+export function wrapLooseText(children: any, trace: boolean = false) {
   // if loose text pieces alongside blocks, strip spurious blank ones,
   // collecting successive non-blank text pieces into p's.
   if (children.length > 1) {
@@ -120,12 +120,15 @@ export function wrapLooseText(children: any) {
       const result = collectTextsIntoParagraphs(
         children.filter((c: any) => !isBlankText(c))
       );
-      /* 
-      if (children.some((b: any) => b.text !== undefined && !isBlankText(b))) {
+
+      if (
+        trace &&
+        children.some((b: any) => b.text !== undefined && !isBlankText(b))
+      ) {
         console.log('wrapText in:' + JSON.stringify(children, null, 2));
         console.log('wrapText out:' + JSON.stringify(result, null, 2));
-      } 
-      */
+      }
+
       return result;
     }
   }

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -13,6 +13,7 @@ import {
   wrapContentInGroup,
   flagStandardContentWarnigns,
   failIfPresent,
+  fixListItemsWithBlocks,
 } from './common';
 import * as DOM from 'src/utils/dom';
 import * as XML from 'src/utils/xml';
@@ -191,6 +192,8 @@ export class WorkbookPage extends Resource {
         const model = introduceStructuredContent(
           r.children[0].children[1].children
         );
+
+        fixListItemsWithBlocks(r);
 
         page.id = r.children[0].id;
         page.legacyId = page.id;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -76,7 +76,8 @@ export function isInlineElement($: any, elem: any) {
 
   if (
     isOneOf(parent[0].name, [
-      'li',
+      // now treat images in li as block
+      // 'li',
       'td',
       'th',
       'dd',


### PR DESCRIPTION
This takes out the code inlining imgs and stripping paragraphs within list items. It also applies an existing routine to fix up block-containing list items to ensure any loose text items within them get wrapped in paragraphs as required by Slate editor. 

The list item fixup is only applied in workbook pages, which are the only cases we have encountered of block items within list items in Chemistry course. It could be added to other resources if a need arises. 