### PR TITLE
[ENHANCEMENT] doublesub and deemphasis styles [MER-1966]

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -545,7 +545,7 @@ function findFromDOM(
 }
 
 const absUrlPrefix = new RegExp('^[a-z]+://', 'i');
-const isRelativeUrl = (url: string): boolean => !url.match(absUrlPrefix);
+const isRelativeUrl = (url: string): boolean => !url.trim().match(absUrlPrefix);
 
 /*
 function isLocalReference(src: string, filePath: string): boolean {

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -115,16 +115,28 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'definition term', 'definition-term');
 
+  // Change sub within sub to distinct doublesub mark. Will remove the
+  // regular sub style from doublesub text when collecting styles in toJSON
+  DOM.rename($, 'sub sub', 'doublesub');
+
   // Convert all inline markup elements to <em> tags, this
   // greatly simplifies downstream conversionto JSON
   $('var').each((i: any, item: any) => $(item).attr('style', 'code'));
   $('term').each((i: any, item: any) => $(item).attr('style', 'term'));
   $('sub').each((i: any, item: any) => $(item).attr('style', 'sub'));
   $('sup').each((i: any, item: any) => $(item).attr('style', 'sup'));
+  $('doublesub').each((i: any, item: any) =>
+    $(item).attr('style', 'doublesub')
+  );
+  $('deemphasis').each((i: any, item: any) =>
+    $(item).attr('style', 'deemphasis')
+  );
   DOM.rename($, 'var', 'em');
   DOM.rename($, 'term', 'em');
   DOM.rename($, 'sub', 'em');
   DOM.rename($, 'sup', 'em');
+  DOM.rename($, 'doublesub', 'em');
+  DOM.rename($, 'deemphasis', 'em');
 
   // <code> is a mixed element, we only want to translate the inline <code>
   // instances to <em> elements.  The block level <code> will get converted

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -60,6 +60,10 @@ function inlineAttrName(attrs: Record<string, unknown>) {
     return 'sub';
   } else if (attrs['style'] === 'sup') {
     return 'sup';
+  } else if (attrs['style'] === 'doublesub') {
+    return 'doublesub';
+  } else if (attrs['style'] === 'deemphasis') {
+    return 'deemphasis';
   } else {
     return 'strong';
   }
@@ -68,6 +72,7 @@ function inlineAttrName(attrs: Record<string, unknown>) {
 function inlinesToObject(inlines: any) {
   return inlines.reduce((m: any, style: any) => {
     m[style] = true;
+    if (style === 'doublesub') delete m['sub'];
     return m;
   }, {});
 }


### PR DESCRIPTION
This adds digest support for outputting 'doublesub' style for double subscripted text and carrying through the 'deemphasis' style for text marked this way in legacy (rendered as normal weight and grey; used in French in some presentations of words with silent letters). Rendering of both of these requires changes on the torus side. 

This also incorporates an unrelated minor fix to trim URLs before checking for relative URLs, needed to get  French content through the digest tool in latest version.