### PR TITLE
[BUGFIX] prevent undesired inlining of images, formula [MER-2003] [MER-2073] [MER-2100]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -161,7 +161,8 @@ export function standardContentManipulations($: any) {
   // image in a legacy course is intended as a block semantically, with
   // newlines before or after, converting to inline images feels like
   // a closer mapping to the correct rendering.
-  DOM.rename($, 'p img', 'img_inline');
+  // AW: this undesirable for images inside paragraphs
+  // DOM.rename($, 'p img', 'img_inline');
   DOM.rename($, 'a img', 'img_inline');
 
   $('img').each((i: any, item: any) => {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -85,8 +85,9 @@ export function isInlineElement($: any, elem: any) {
       'choice',
       'feedback',
       'hint',
-      'stem',
-      'body',
+      // AW: inlining in these contexts leads to undesired left-alignment:
+      // 'stem',
+      // 'body',
     ])
   ) {
     if (parent[0].children.length === 1) {


### PR DESCRIPTION
Modify rule used to decide which mixed elements should be inline to avoid undesired inlining of images and formula within page bodies, which was keeping them from being centered and loses their captions causing multiple issue reports. 

One effect is to change these images to torus figure format which always has a light grey background. This differs from legacy display, but seems preferable overall. 