### PR TITLE
[Bugfix] Fixed bug causing formulas to import as inline when they could be block

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -161,7 +161,8 @@ export function standardContentManipulations($: any) {
   // image in a legacy course is intended as a block semantically, with
   // newlines before or after, converting to inline images feels like
   // a closer mapping to the correct rendering.
-  DOM.rename($, 'p img', 'img_inline');
+  // AW: this undesirable for images inside paragraphs
+  // DOM.rename($, 'p img', 'img_inline');
   DOM.rename($, 'a img', 'img_inline');
 
   $('img').each((i: any, item: any) => {

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -91,7 +91,7 @@ export function buildStem(
   skipInputRefValidation: boolean
 ) {
   const stem = Common.getChild(question.children, 'stem');
-  const model = Common.ensureParagraphs(stem.children);
+  const model = Common.wrapLooseText(Common.ensureParagraphs(stem.children));
   const foundInputs: any = {};
   const updated = updateInputRefs(model, foundInputs);
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -69,6 +69,9 @@ export function flattenResourceRefs($: any) {
   $('duplicate').remove();
 }
 
+const removeEmptyText = (elem: any) =>
+  !(elem.type === 'text' && elem.data.trim() === '');
+
 // Utility function that allows determining whether an instance of a mixed type element (e.g. formula) is
 // needs to be considered inline or block.
 export function isInlineElement($: any, elem: any) {
@@ -93,9 +96,12 @@ export function isInlineElement($: any, elem: any) {
       return false;
     }
 
-    return parent[0].children.some(
-      (c: any) => c.type === 'text' || (c.type == 'tag' && isInlineTag(c.name))
-    );
+    return parent[0].children
+      .filter(removeEmptyText)
+      .some(
+        (c: any) =>
+          c.type === 'text' || (c.type == 'tag' && isInlineTag(c.name))
+      );
   }
   return false;
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -88,8 +88,9 @@ export function isInlineElement($: any, elem: any) {
       'choice',
       'feedback',
       'hint',
-      'stem',
-      'body',
+      // AW: inlining in these contexts leads to undesired left-alignment:
+      // 'stem',
+      // 'body',
     ])
   ) {
     if (parent[0].children.length === 1) {

--- a/test/content/x-oli-assessment2-pool/po7_orbital_dia_UA_pool.xml
+++ b/test/content/x-oli-assessment2-pool/po7_orbital_dia_UA_pool.xml
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pool PUBLIC "-//Carnegie Mellon University//DTD Assessment Pool MathML 2.4//EN" "http://oli.web.cmu.edu/dtd/oli_assessment_mathml_2_4.dtd">
+<pool xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="po7_orbital_dia_UA_pool">
+    <title>orbital_dia_UA_pool</title>
+    <content available="always">
+        <p id="f8ce447db495428883112bf655747fbd"/>
+    </content>
+    <fill_in_the_blank id="po7_v1_orbital_dia">
+        <body>The abbreviated orbital diagram for an atom is shown below. <image
+                src="../webcontent/ua_v1_orbital_dia.PNG"/>
+            <p> What element is represented by this orbital diagram? <input_ref input="one"/>
+            </p>
+            <p> Which element will have chemical properties most similar to those of the element
+                represented above? <input_ref input="two"/>
+            </p>
+            <p>How many valence electrons does this atom have? <input_ref input="three"/></p>
+            <p>How many unpaired electrons does this atom have? <input_ref input="four"/></p>
+        </body>
+        <input id="one" shuffle="false">
+            <choice value="A">As </choice>
+            <choice value="B">Br</choice>
+            <choice value="C">P</choice>
+            <choice value="D">Se</choice>
+            <choice value="E">Te </choice>
+
+
+        </input>
+        <input id="two" shuffle="false">
+            <choice value="A">As </choice>
+            <choice value="B">Br</choice>
+            <choice value="C">P</choice>
+            <choice value="D">Se</choice>
+            <choice value="E">Te </choice>
+        </input>
+        <input shuffle="false" id="three">
+            <choice value="A">4 </choice>
+            <choice value="B">6</choice>
+            <choice value="C">10</choice>
+            <choice value="D">16</choice>
+        </input>
+
+        <input shuffle="false" id="four">
+            <choice value="A">0 </choice>
+            <choice value="B">1</choice>
+            <choice value="C">2</choice>
+            <choice value="D">3</choice>
+            <choice value="E">4</choice>
+        </input>
+
+        <part id="one" score_out_of="3">
+            <response match="A" input="one" score="0">
+                <feedback>Incorrect. Atoms of As have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>3</sup>. </feedback>
+           <feedback>Incorrect. 
+           <p><em>Solution</em></p>
+           Atoms of Se have the electron configuration
+           [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. 
+           </feedback>
+            </response>
+            <response match="B" input="one" score="0">
+                <feedback>Incorrect. Atoms of Br have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>5</sup>. </feedback>
+                <feedback>Incorrect. 
+                    <p><em>Solution</em></p>
+                    Atoms of Se have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. 
+                </feedback>
+            
+            </response>
+
+            <response match="C" input="one" score="0">
+                <feedback>Incorrect. Atoms of S have the electron configuration
+                    [Ne]3<em style="italic">s</em><sup>2</sup>3<em style="italic">p</em><sup>4</sup>. </feedback>
+                <feedback>Incorrect. 
+                    <p><em>Solution</em></p>
+                    Atoms of Se have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. 
+                </feedback>
+            
+            </response>
+
+            <response match="D" input="one" score="3">
+                <feedback>Correct. Atoms of Se have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. </feedback>
+            </response>
+
+            <response match="E" input="one" score="0">
+                <feedback>Incorrect. Atoms of Te have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>. </feedback>
+                <feedback>Incorrect. 
+                    <p><em>Solution</em></p>
+                    Atoms of Se have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. 
+                </feedback>
+            
+            </response>
+
+
+        </part>
+        <part id="two" score_out_of="3">
+            <response match="E" input="two" score="3">
+                <feedback>Correct. Te has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+            <response match="*" input="two" score="0">
+                <feedback>Incorrect. An element has chemical properties that are most similar to
+                    other elements in the same Group (column) in the periodic table. </feedback>
+                <feedback>Incorrect. 
+                <p><em>Solution</em></p>
+                Te has chemical properties most similar to this element since it
+                is in the same Group (column) in the periodic table.
+                </feedback>
+            </response>
+
+
+        </part>
+
+        <part id="three" score_out_of="3">
+            <response match="B" input="three" score="3">
+                <feedback>Correct. This atom has 6 valence (outer shell) electrons. </feedback>
+            </response>
+            <response match="*" input="three" score="0">
+                <feedback>Incorrect. The valence electrons are (only) the outer shell electrons.
+                </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 6 valence (outer shell) electrons. </feedback>
+            </response>
+
+
+        </part>
+        <part id="four" score_out_of="3">
+            <response match="C" input="four" score="3">
+                <feedback>Correct. This atom has 2 unpaired electrons. </feedback>
+            </response>
+            <response match="*" input="four" score="0">
+                <feedback>Incorrect. An electron is 'unpaired' if it is the only electron in an
+                    orbital. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p> This atom has 2 unpaired electrons. </feedback>
+            </response>
+
+
+        </part>
+
+    </fill_in_the_blank>
+    <fill_in_the_blank id="po7_v2_orbital_dia">
+        <body>The abbreviated orbital diagram for an atom is shown below. <image
+                src="../webcontent/ua_v2_orbital_dia.PNG"/>
+            <p> What element is represented by this orbital diagram? <input_ref input="one"/>
+            </p>
+            <p> Which element will have chemical properties most similar to those of the element
+                represented above? <input_ref input="two"/>
+            </p>
+            <p>How many valence electrons does this atom have? <input_ref input="three"/></p>
+            <p>How many unpaired electrons does this atom have? <input_ref input="four"/></p>
+        </body>
+        <input id="one" shuffle="false">
+            <choice value="A">Br </choice>
+            <choice value="B">Cl</choice>
+            <choice value="C">I</choice>
+            <choice value="D">Kr</choice>
+            <choice value="E">Se </choice>
+
+
+        </input>
+        <input id="two" shuffle="false">
+            <choice value="A">I </choice>
+            <choice value="B">Kr</choice>
+            <choice value="C">Se</choice>
+            <choice value="D">Te</choice>
+            <choice value="E">Xe </choice>
+
+        </input>
+        <input shuffle="false" id="three">
+            <choice value="A">5 </choice>
+            <choice value="B">7</choice>
+            <choice value="C">10</choice>
+            <choice value="D">17</choice>
+        </input>
+
+        <input shuffle="false" id="four">
+            <choice value="A">0 </choice>
+            <choice value="B">1</choice>
+            <choice value="C">2</choice>
+            <choice value="D">3</choice>
+            <choice value="E">4</choice>
+        </input>
+
+        <part id="one" score_out_of="3">
+            <response match="A" input="one" score="3">
+                <feedback>Correct. Atoms of Br have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>5</sup>. </feedback>
+            </response>
+            <response match="B" input="one" score="0">
+                <feedback>Incorrect. Atoms of Cl have the electron configuration
+                    [Ne]3<em style="italic">s</em><sup>2</sup>3<em style="italic">p</em><sup>5</sup>. </feedback>
+                <feedback>Incorrect.
+                <p><em>Solution</em></p>
+                Atoms of Br have the electron configuration
+                [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>5</sup>.
+                </feedback>
+            </response>
+
+            <response match="C" input="one" score="0">
+                <feedback>Incorrect. Atoms of I have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>5</sup>. </feedback>
+           
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Br have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>5</sup>.
+                </feedback>
+            </response>
+
+            <response match="D" input="one" score="0">
+                <feedback>Incorrect. Atoms of Kr have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>6</sup>. </feedback>
+           
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Br have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>5</sup>.
+                </feedback>
+            </response>
+
+            <response match="E" input="one" score="0">
+                <feedback>Incorrect. Atoms of Se have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. </feedback>
+          
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Br have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>5</sup>.
+                </feedback>
+            </response>
+
+
+        </part>
+        <part id="two" score_out_of="3">
+            <response match="A" input="two" score="3">
+                <feedback>Correct. I has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+            <response match="*" input="two" score="0">
+                <feedback>Incorrect. An element has chemical properties that are most similar to
+                    other elements in the same Group (column) in the periodic table. </feedback>
+                <feedback>Incorrect. 
+                    <p><em>Solution</em></p>
+                    
+                    I has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+
+
+        </part>
+
+        <part id="three" score_out_of="3">
+            <response match="B" input="three" score="3">
+                <feedback>Correct. This atom has 7 valence (outer shell) electrons. </feedback>
+            </response>
+            <response match="*" input="three" score="0">
+                <feedback>Incorrect. The valence electrons are (only) the outer shell electrons.
+                </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 7 valence (outer shell) electrons. </feedback>
+            </response>
+
+
+        </part>
+        <part id="four" score_out_of="3">
+            <response match="B" input="four" score="3">
+                <feedback>Correct. This atom has 1 unpaired electron. </feedback>
+            </response>
+            <response match="*" input="four" score="0">
+                <feedback>Incorrect. An electron is 'unpaired' if it is the only electron in an
+                    orbital. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 1 unpaired electron. </feedback>
+            </response>
+
+
+        </part>
+
+    </fill_in_the_blank>
+    <fill_in_the_blank id="po7_v3_orbital_dia">
+        <body>The abbreviated orbital diagram for an atom is shown below. <image
+                src="../webcontent/ua_v3_orbital_dia.PNG"/>
+            <p> What element is represented by this orbital diagram? <input_ref input="one"/>
+            </p>
+            <p> Which element will have chemical properties most similar to those of the element
+                represented above? <input_ref input="two"/>
+            </p>
+            <p>How many valence electrons does this atom have? <input_ref input="three"/></p>
+            <p>How many unpaired electrons does this atom have? <input_ref input="four"/></p>
+        </body>
+        <input id="one" shuffle="false">
+            <choice value="A">As </choice>
+            <choice value="B">Bi</choice>
+            <choice value="C">Sb</choice>
+            <choice value="D">Sn</choice>
+            <choice value="E">Te </choice>
+
+
+        </input>
+        <input id="two" shuffle="false">
+            <choice value="A">Bi</choice>
+            <choice value="B">Pb</choice>
+            <choice value="C">Po</choice>
+            <choice value="D">Sn</choice>
+            <choice value="E">Te </choice>
+
+        </input>
+        <input shuffle="false" id="three">
+            <choice value="A">3 </choice>
+            <choice value="B">5</choice>
+            <choice value="C">10</choice>
+            <choice value="D">15</choice>
+        </input>
+
+        <input shuffle="false" id="four">
+            <choice value="A">0 </choice>
+            <choice value="B">1</choice>
+            <choice value="C">2</choice>
+            <choice value="D">3</choice>
+            <choice value="E">4</choice>
+        </input>
+
+        <part id="one" score_out_of="3">
+            <response match="A" input="one" score="0">
+                <feedback>Incorrect. Atoms of As have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>3</sup>. </feedback>
+           
+            <feedback>Incorrect.
+            <p><em>Solution</em></p>
+            Atoms of Sb have the electron configuration
+            [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>3</sup>.
+            </feedback>
+            </response>
+            <response match="B" input="one" score="0">
+                <feedback>Incorrect. Atoms of Bi have the electron configuration
+                    [Xe]6<em style="italic">s</em><sup>2</sup>4<em style="italic">f</em><sup>14</sup>5<em style="italic">d</em><sup>10</sup>6<em style="italic">p</em><sup>3</sup>. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Sb have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>3</sup>.
+                </feedback>
+            
+            </response>
+
+            <response match="C" input="one" score="3">
+                <feedback>Correct. Atoms of Sb have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>3</sup>. </feedback>
+            </response>
+
+            <response match="D" input="one" score="0">
+                <feedback>Incorrect. Atoms of Sn have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>2</sup>. </feedback>
+            
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Sb have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>3</sup>.
+                </feedback>
+            </response>
+
+            <response match="E" input="one" score="0">
+                <feedback>Incorrect. Atoms of Te have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>. </feedback>
+          
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Sb have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>3</sup>.
+                </feedback>
+            </response>
+
+
+        </part>
+        <part id="two" score_out_of="3">
+            <response match="A" input="two" score="3">
+                <feedback>Correct. Bi has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+            <response match="*" input="two" score="0">
+                <feedback>Incorrect. An element has chemical properties that are most similar to
+                    other elements in the same Group (column) in the periodic table. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Bi has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+
+
+        </part>
+
+        <part id="three" score_out_of="3">
+            <response match="B" input="three" score="3">
+                <feedback>Correct. This atom has 5 valence (outer shell) electrons. </feedback>
+            </response>
+            <response match="*" input="three" score="0">
+                <feedback>Incorrect. The valence electrons are (only) the outer shell electrons.
+                </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 5 valence (outer shell) electrons. </feedback>
+            </response>
+
+
+        </part>
+        <part id="four" score_out_of="3">
+            <response match="D" input="four" score="3">
+                <feedback>Correct. This atom has 3 unpaired electrons. </feedback>
+            </response>
+            <response match="*" input="four" score="0">
+                <feedback>Incorrect. An electron is 'unpaired' if it is the only electron in an
+                    orbital. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 3 unpaired electrons. </feedback>
+            </response>
+
+
+        </part>
+
+    </fill_in_the_blank>
+
+
+    <fill_in_the_blank id="po7_v4_orbital_dia">
+        <body>The abbreviated orbital diagram for an atom is shown below. <image
+                src="../webcontent/ua_v4_orbital_dia.PNG"/>
+            <p> What element is represented by this orbital diagram? <input_ref input="one"/>
+            </p>
+            <p> Which element will have chemical properties most similar to those of the element
+                represented above? <input_ref input="two"/>
+            </p>
+            <p>How many valence electrons does this atom have? <input_ref input="three"/></p>
+            <p>How many unpaired electrons does this atom have? <input_ref input="four"/></p>
+        </body>
+        <input id="one" shuffle="false">
+            <choice value="A">I</choice>
+            <choice value="B">Po</choice>
+            <choice value="C">Se</choice>
+            <choice value="D">Sb</choice>
+            <choice value="E">Te </choice>
+
+
+        </input>
+        <input id="two" shuffle="false">
+            <choice value="A">At</choice>
+            <choice value="B">Bi</choice>
+            <choice value="C">I</choice>
+            <choice value="D">Po</choice>
+            <choice value="E">Sb </choice>
+
+        </input>
+        <input shuffle="false" id="three">
+            <choice value="A">4 </choice>
+            <choice value="B">6</choice>
+            <choice value="C">10</choice>
+            <choice value="D">16</choice>
+        </input>
+
+        <input shuffle="false" id="four">
+            <choice value="A">0 </choice>
+            <choice value="B">1</choice>
+            <choice value="C">2</choice>
+            <choice value="D">3</choice>
+            <choice value="E">4</choice>
+        </input>
+
+        <part id="one" score_out_of="3">
+            <response match="A" input="one" score="0">
+                <feedback>Incorrect. Atoms of As have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>5</sup>. </feedback>
+            <feedback>Incorrect.
+            <p><em>Solution</em></p>
+            Atoms of Te have the electron configuration
+            [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>.
+            </feedback>
+            
+            </response>
+            <response match="B" input="one" score="0">
+                <feedback>Incorrect. Atoms of Po have the electron configuration
+                    [Xe]6<em style="italic">s</em><sup>2</sup>4<em style="italic">f</em><sup>14</sup>5<em style="italic">d</em><sup>10</sup>6<em style="italic">p</em><sup>4</sup>. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Te have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>.
+                </feedback>
+            
+            </response>
+
+            <response match="C" input="one" score="0">
+                <feedback>Incorrect. Atoms of Se have the electron configuration
+                    [Ar]4<em style="italic">s</em><sup>2</sup>3<em style="italic">d</em><sup>10</sup>4<em style="italic">p</em><sup>4</sup>. </feedback>
+           
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Te have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>.
+                </feedback>
+            </response>
+
+            <response match="D" input="one" score="0">
+                <feedback>Incorrect. Atoms of Sb have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>3</sup>. </feedback>
+            
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Atoms of Te have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>.
+                </feedback>
+            </response>
+
+            <response match="E" input="one" score="3">
+                <feedback>Correct. Atoms of Te have the electron configuration
+                    [Kr]5<em style="italic">s</em><sup>2</sup>4<em style="italic">d</em><sup>10</sup>5<em style="italic">p</em><sup>4</sup>. </feedback>
+            </response>
+
+
+        </part>
+        <part id="two" score_out_of="3">
+            <response match="D" input="two" score="3">
+                <feedback>Correct. Te has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+            <response match="*" input="two" score="0">
+                <feedback>Incorrect. An element has chemical properties that are most similar to
+                    other elements in the same Group (column) in the periodic table. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    Te has chemical properties most similar to this element since it
+                    is in the same Group (column) in the periodic table. </feedback>
+            </response>
+
+
+        </part>
+
+        <part id="three" score_out_of="3">
+            <response match="B" input="three" score="3">
+                <feedback>Correct. This atom has 6 valence (outer shell) electrons. </feedback>
+            </response>
+            <response match="*" input="three" score="0">
+                <feedback>Incorrect. The valence electrons are (only) the outer shell electrons.
+                </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 6 valence (outer shell) electrons. </feedback>
+            </response>
+
+
+        </part>
+        <part id="four" score_out_of="3">
+            <response match="C" input="four" score="3">
+                <feedback>Correct. This atom has 2 unpaired electrons.</feedback>
+            </response>
+            <response match="*" input="four" score="0">
+                <feedback>Incorrect. An electron is 'unpaired' if it is the only electron in an
+                    orbital. </feedback>
+                <feedback>Incorrect.
+                    <p><em>Solution</em></p>
+                    This atom has 2 unpaired electrons.</feedback>
+            </response>
+
+
+        </part>
+
+    </fill_in_the_blank>
+
+
+
+
+</pool>

--- a/test/content/x-oli-workbook_page/p1_changes_enthalpy.xml
+++ b/test/content/x-oli-workbook_page/p1_changes_enthalpy.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC " -//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page id="p1_changes_enthalpy" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/"
+    xmlns:bib="http://bibtexml.sf.net/" xmlns:pref="http://oli.web.cmu.edu/preferences/"
+    xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:theme="http://oli.web.cmu.edu/presentation/"
+    xmlns:wb="http://oli.web.cmu.edu/activity/workbook/">
+
+
+    <head>
+        <title>Changes in Enthalpy</title>
+        <objref idref="enthalpy" />
+    </head>
+
+    <body>
+        <p>
+            <activity_link idref="Periodic_Table" target="new">
+                <em>Reference: The Periodic Table of Elements</em>
+            </activity_link>
+        </p>
+        <p>Chemists ordinarily use a property known as enthalpy (<em style="italic">H</em>) to
+            describe the thermodynamics of chemical and physical processes. Enthalpy is defined as
+            the sum of a system’s internal energy (<em style="italic">E</em>) and the mathematical
+            product of its pressure (<em style="italic">P</em>) and volume (<em style="italic"
+            >V</em>
+            ):</p>
+        <formula><em style="italic">H</em> = <em style="italic">E</em> + <em style="italic"
+            >PV</em></formula>
+        <p>Since it is derived from three state functions (<em style="italic">E</em>, <em
+                style="italic">P</em>, and <em style="italic">V</em>), enthalpy is also a state
+            function. Enthalpy values for specific substances cannot be measured directly; only
+            enthalpy changes for chemical or physical processes can be determined. For processes
+            that take place at constant pressure (a common condition for many chemical and physical
+            changes), the enthalpy change (Δ<em style="italic">H</em>) is:</p>
+        <formula>Δ<em style="italic">H</em> = Δ<em style="italic">E</em> + <em style="italic"
+            >P</em>Δ<em
+                style="italic">V</em>
+        </formula>
+        <p>The mathematical product <em style="italic">P</em>Δ<em style="italic">V</em> represents
+            work (<em style="italic">w</em>), namely, expansion or pressure-volume work as noted. By
+            their definitions, the arithmetic signs of Δ<em style="italic">V</em> and <em
+                style="italic">w</em> will always be opposite:</p>
+        <p> Substituting this equation into the enthalpy-change equation yields: </p>
+        <formula>Δ<em style="italic">H</em> = Δ<em style="italic">E</em> + <em style="italic"
+            >P</em>Δ<em
+                style="italic">V</em></formula>
+        <formula><em style="italic">P</em>Δ<em style="italic">V</em> = Δ<em style="italic">E</em> - <em
+                style="italic">w</em> (at constant pressure, <em style="italic"
+            >P</em>)</formula>
+
+    </body>
+</workbook_page>

--- a/test/content/x-oli-workbook_page/p1_changes_enthalpy.xml
+++ b/test/content/x-oli-workbook_page/p1_changes_enthalpy.xml
@@ -47,5 +47,18 @@
                 style="italic">w</em> (at constant pressure, <em style="italic"
             >P</em>)</formula>
 
+        <table>
+            <tbody>
+                <tr>
+                    <td>
+                        <p>Some text</p>
+                        <formula>Some formula</formula>
+                        <formula>Some formula</formula>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+
     </body>
 </workbook_page>

--- a/test/resources/common-test.ts
+++ b/test/resources/common-test.ts
@@ -51,7 +51,7 @@ describe('cdata and codeblocks', () => {
     expect(img.type).toBe('img');
   });
 
-  test('should convert nested images to inline imgs', async () => {
+  test('should convert some nested images to inline imgs', async () => {
     const content1 = '<p><image src="../webcontent/proof_prem.gif"/></p>';
     const content2 = '<a><image src="../webcontent/proof_prem.gif"/></a>';
 
@@ -67,10 +67,10 @@ describe('cdata and codeblocks', () => {
     standardContentManipulations($1);
     const p1: any = await toJSON($1.xml(), projectSummary);
     const img1 = p1.children[0].children[0];
-    expect(img1.type).toBe('img_inline');
+    expect(img1.type).toBe('img');
 
     standardContentManipulations($2);
-    const p2: any = await toJSON($1.xml(), projectSummary);
+    const p2: any = await toJSON($2.xml(), projectSummary);
     const img2 = p2.children[0].children[0];
     expect(img2.type).toBe('img_inline');
   });

--- a/test/resources/formula-math-test.ts
+++ b/test/resources/formula-math-test.ts
@@ -1,5 +1,8 @@
 import { handleFormulaMathML } from 'src/resources/common';
 import * as cheerio from 'cheerio';
+import { WorkbookPage } from 'src/resources/workbook';
+import { MediaSummary } from 'src/media';
+import { ProjectSummary } from 'src/project';
 
 function process(xml: string): any {
   const $ = cheerio.load(xml, {
@@ -9,8 +12,40 @@ function process(xml: string): any {
   handleFormulaMathML($);
   return $.xml();
 }
+const mediaSummary: MediaSummary = {
+  mediaItems: {},
+  missing: [],
+  urlPrefix: '',
+  downloadRemote: false,
+  flattenedNames: {},
+};
+
+const projectSummary = new ProjectSummary('', '', '', mediaSummary);
 
 describe('formulas and mathml', () => {
+  test('should convert formulas to block callouts from enthalpy sample page', async () => {
+    // MER-2130
+    await new WorkbookPage(
+      './test/content/x-oli-workbook_page/p1_changes_enthalpy.xml',
+      true
+    )
+      .convert(projectSummary)
+      .then((results) => {
+        expect((results[0] as any).content.model[0].children[2].type).toBe(
+          'callout'
+        );
+      });
+  });
+
+  test('should convert formulas to callouts', () => {
+    expect(
+      process(
+        '<body><p>Paragraph Before</p><formula>Δ<em style="italic">H</em> = Δ<em style="italic">E</em> + <em style="italic">P</em>Δ<em style="italic">V</em></formula><p>Paragraph After</p></body>'
+      )
+    ).toContain(
+      '<callout><p>&#x394;<em style="italic">H</em> = &#x394;<em style="italic">E</em> + <em style="italic">P</em>&#x394;<em style="italic">V</em></p></callout>'
+    );
+  });
   test('should properly identify and convert inlines', () => {
     expect(
       process('<body><formula>test</formula><p>test</p></body>').indexOf(

--- a/test/resources/formula-math-test.ts
+++ b/test/resources/formula-math-test.ts
@@ -31,6 +31,13 @@ describe('formulas and mathml', () => {
     )
       .convert(projectSummary)
       .then((results) => {
+        // This one checks the formula in the table cell
+        expect(
+          (results[0] as any).content.model[0].children[9].children[0]
+            .children[0].children[0].children[3].type
+        ).toBe('callout');
+
+        // This checks the root level callouts
         expect((results[0] as any).content.model[0].children[2].type).toBe(
           'callout'
         );

--- a/test/utils/dom-test.ts
+++ b/test/utils/dom-test.ts
@@ -9,6 +9,24 @@ import {
 import * as cheerio from 'cheerio';
 
 describe('dom mutations', () => {
+  test('blank text elements implicityly created by whitespace in a body tag should not affect isInlineElement test', () => {
+    const content = `<body>
+      <p></p>
+      <formula>hi</formula>
+      <p></p>
+    </body>`;
+
+    const $ = cheerio.load(content, {
+      normalizeWhitespace: true,
+      xmlMode: true,
+    });
+
+    const refs = $('formula');
+
+    refs.each((i: any, elem: any) => {
+      expect(isInlineElement($, elem)).toBeFalsy();
+    });
+  });
   test('should return that the formula is not inline', () => {
     const content = '<td><formula>test</formula></td>';
 

--- a/test/utils/step-wrap-test.ts
+++ b/test/utils/step-wrap-test.ts
@@ -1,0 +1,37 @@
+import { MediaSummary } from 'src/media';
+import { ProjectSummary } from 'src/project';
+import { Summative } from 'src/resources/summative';
+
+const mediaSummary: MediaSummary = {
+  mediaItems: {},
+  missing: [],
+  urlPrefix: '',
+  downloadRemote: false,
+  flattenedNames: {},
+};
+
+const projectSummary = new ProjectSummary('', '', '', mediaSummary);
+
+describe('multi input stem handling', () => {
+  test('should wrap raw text in stems', async () => {
+    await new Summative(
+      './test/content/x-oli-assessment2-pool/po7_orbital_dia_UA_pool.xml',
+      true
+    )
+      .convert(projectSummary)
+      .then((results) => {
+        const activities = results.filter(
+          (a: any) => a.id === 'po7_orbital_dia_UA_pool-po7_v1_orbital_dia'
+        );
+        for (const activity of activities) {
+          const stem = (activity as any).content.stem;
+
+          const textNodes = stem.content.filter((child: any) =>
+            child.hasOwnProperty('text')
+          );
+
+          expect(textNodes.length).toBe(0);
+        }
+      });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/Simon-Initiative/oli-torus/issues/3642

To reproduce:
1. Have a <formula> with plaintext in it directly in the body of a document
2. Convert that to torus format

Expected: It gets converted to a callout
Actual: callout_inline

The test for whether the element should be inline or not includes checking for text-nodes as siblings. That test didn't filter out empty text nodes, and returned a false-positive for requiring it to be inline

