### PR TITLE
[ENHANCEMENT] Pass through grading attribute in oli_short_answer essay questions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ out/
 amisc/
 test/course_packages/**/.svn
 test/course_packages/migration-4sdfykby_v_1_0-echo/~$skill_map.xlsx
+test/course_packages/migration-4sdfykby_v_1_0-echo-out
+test/course_packages/migration-4sdfykby_v_1_0-echo-converted

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -334,6 +334,7 @@ function single_response_text(question: any) {
     stem: Common.buildStem(question),
     inputType: 'text',
     submitAndCompare: Common.isSubmitAndCompare(question),
+    grading: question.grading,
     authoring: {
       parts: [Common.buildTextPart(Common.getPartIds(question)[0], question)],
       transformations: transformation === undefined ? [] : [transformation],

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -334,7 +334,6 @@ function single_response_text(question: any) {
     stem: Common.buildStem(question),
     inputType: 'text',
     submitAndCompare: Common.isSubmitAndCompare(question),
-    grading: question.grading,
     authoring: {
       parts: [Common.buildTextPart(Common.getPartIds(question)[0], question)],
       transformations: transformation === undefined ? [] : [transformation],

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -260,19 +260,18 @@ export function getBranchingTarget(response: any) {
   return response.children[0]['xml:lang'];
 }
 
+function getGradingApproach(question: any) {
+  return question.grading === 'instructor' ? 'manual' : 'automatic';
+}
+
 export function buildTextPart(id: string, question: any) {
-  const responses = getChild(question.children, 'part').children.filter(
-    (p: any) => p.type === 'response'
-  );
-  const hints = getChild(question.children, 'part').children.filter(
-    (p: any) => p.type === 'hint'
-  );
-  const skillrefs = getChild(question.children, 'part').children.filter(
-    (p: any) => p.type === 'skillref'
-  );
+  const part = getChild(question.children, 'part');
+  const responses = part.children.filter((p: any) => p.type === 'response');
+  const hints = part.children.filter((p: any) => p.type === 'hint');
+  const skillrefs = part.children.filter((p: any) => p.type === 'skillref');
 
   return {
-    id: '1',
+    id: part.id,
     responses: responses.map((r: any) => {
       const cleanedMatch = convertCatchAll(r.match);
       const item: any = {
@@ -302,6 +301,7 @@ export function buildTextPart(id: string, question: any) {
     objectives: skillrefs.map((s: any) => s.idref),
     scoringStrategy: 'average',
     explanation: maybeBuildPartExplanation(responses),
+    gradingApproach: getGradingApproach(question),
   };
 }
 

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/assessment_with_grading.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/assessment_with_grading.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Assessment MathML 2.4//EN" "http://oli.web.cmu.edu/dtd/oli_assessment_mathml_2_4.dtd">
-<assessment xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="d0122cf806954b40ac9beba5c24aab13" recommended_attempts="3" max_attempts="3">
+<assessment xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="assessment_with_grading" recommended_attempts="3" max_attempts="3">
     <title>Module test: Effective Digital Learning (Essay Active Learning)</title>
     <page id="ea466b8c12654495919407f478424d6b">
         <title>Page 1</title>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/assessment_with_grading.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/assessment_with_grading.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Assessment MathML 2.4//EN" "http://oli.web.cmu.edu/dtd/oli_assessment_mathml_2_4.dtd">
+<assessment xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="d0122cf806954b40ac9beba5c24aab13" recommended_attempts="3" max_attempts="3">
+    <title>Module test: Effective Digital Learning (Essay Active Learning)</title>
+    <page id="ea466b8c12654495919407f478424d6b">
+        <title>Page 1</title>
+        <essay id="de863cf6eecd46828909a1cbb70614e1" grading="instructor">
+            <body>
+                <p id="c49a13fa12a04314a0ae74dd0fb1c0c1">In your own words, with examples from your own field, explain the concept of
+                    <em style="italic">active learning.</em>
+                </p>
+            </body>
+            <part id="ffffdc1d54624b6ca9e19277e108f6a2">
+                <response match="*" score="1">
+                    <feedback>
+                        <p id="ba6a1620bb8e42da8097a660d09fe706" />
+                    </feedback>
+                </response>
+            </part>
+        </essay>
+    </page>
+</assessment>

--- a/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
+++ b/test/course_packages/migration-4sdfykby_v_1_0-echo/organizations/default/organization.xml
@@ -126,6 +126,9 @@
           <item id="bca2e8dcf45e4ca588989dc18a62d29" scoring_mode="default">
             <resourceref idref="assessment_with_selection" />
           </item>
+          <item id="bca2e8dcf45e4ca588989dc18a62d30" scoring_mode="default">
+            <resourceref idref="assessment_with_grading" />
+          </item>
         </module>
         <module id="dnd">
           <title>
@@ -159,7 +162,6 @@
             <resourceref idref="histogram1" />
           </item>
         </module>
-
         <module id="bugfixes">
           <title>
             Bug Fixes

--- a/test/resources/feedback-test.ts
+++ b/test/resources/feedback-test.ts
@@ -689,6 +689,7 @@ describe('convert feedback', () => {
             parts: [
               {
                 id: expect.any(String),
+                gradingApproach: 'automatic',
                 responses: [
                   {
                     id: expect.any(String),

--- a/test/resources/summative-test.ts
+++ b/test/resources/summative-test.ts
@@ -570,7 +570,14 @@ describe('convert summative', () => {
         id: 'd0122cf806954b40ac9beba5c24aab13-de863cf6eecd46828909a1cbb70614e1',
         subType: 'oli_short_answer',
         content: expect.objectContaining({
-          grading: 'instructor',
+          authoring: expect.objectContaining({
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                id: 'ffffdc1d54624b6ca9e19277e108f6a2',
+                gradingApproach: 'manual',
+              }),
+            ]),
+          }),
         }),
       })
     );

--- a/test/resources/summative-test.ts
+++ b/test/resources/summative-test.ts
@@ -567,7 +567,7 @@ describe('convert summative', () => {
     expect(converted).toContainEqual(
       expect.objectContaining({
         type: 'Activity',
-        id: 'd0122cf806954b40ac9beba5c24aab13-de863cf6eecd46828909a1cbb70614e1',
+        id: 'assessment_with_grading-de863cf6eecd46828909a1cbb70614e1',
         subType: 'oli_short_answer',
         content: expect.objectContaining({
           authoring: expect.objectContaining({

--- a/test/resources/summative-test.ts
+++ b/test/resources/summative-test.ts
@@ -543,4 +543,36 @@ describe('convert summative', () => {
       })
     );
   });
+
+  it('converts essay with grading manual', async () => {
+    const file =
+      'test/course_packages/migration-4sdfykby_v_1_0-echo/content/x-oli-assessment2/assessment_with_grading.xml';
+    const mediaSummary: Media.MediaSummary = {
+      mediaItems: {},
+      missing: [],
+      urlPrefix: '',
+      downloadRemote: false,
+      flattenedNames: {},
+    };
+
+    const projectSummary = new ProjectSummary(
+      'test/course_packages/migration-4sdfykby_v_1_0-echo',
+      '',
+      '',
+      mediaSummary
+    );
+
+    const converted = await convert(projectSummary, file, false);
+
+    expect(converted).toContainEqual(
+      expect.objectContaining({
+        type: 'Activity',
+        id: 'd0122cf806954b40ac9beba5c24aab13-de863cf6eecd46828909a1cbb70614e1',
+        subType: 'oli_short_answer',
+        content: expect.objectContaining({
+          grading: 'instructor',
+        }),
+      })
+    );
+  });
 });


### PR DESCRIPTION
This PR adjusts the digest tool to pass through the `gradingApproach` attribute in oli_short_answer essay questions part.

Includes a unit test and I tested this end-to-end with the migration course and torus identified the essay oli_short_answer activity as instructor manually graded.

https://eliterate.atlassian.net/browse/MER-2071?filter=10067

Closes [#3537](https://github.com/Simon-Initiative/oli-torus/issues/3537)