### PR TITLE
[MER-2072] better handling of xref links

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -601,6 +601,7 @@ export function performRestructure($: any) {
   DOM.remove($, 'no_response');
   DOM.eliminateLevel($, 'section');
   DOM.rename($, 'activity_link', 'a');
+
   // facilitates processing image hotspot questions:
   DOM.rename($, 'image_hotspot hotspot', 'choice');
 

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -97,18 +97,18 @@ export class WorkbookPage extends Resource {
       const hasPage = pageValue !== null && pageValue !== undefined;
       const hasIdref = idref !== null && idref !== undefined;
 
+      // Change it to a link
+      elem.tagName = 'a';
+
       // Type 1: page attr points to another page
-      if (hasPage && !hasIdref) {
+      // Type 2: page attr points to another page, idref to an item within that page (and we ignore it)
+      if (hasPage) {
         $(elem).attr('idref', pageValue);
+        $(elem).removeAttr('page');
         page.unresolvedReferences.push(pageValue);
-
-        // Type 2: page attr points to another page, idref to an item within that page
+        // Type 3: idref points to content item on this page so make a link to this page.
+        //         Should we just remove the link since we don't have capability to link to items on the page in torus?
       } else if (!hasPage && hasIdref) {
-        $(elem).attr('idref', pageValue);
-        page.unresolvedReferences.push(pageValue);
-
-        // Type 3: idref points to content item on this page
-      } else if (hasPage && hasIdref) {
         $(elem).attr('idref', $('workbook_page').attr('id'));
       }
     });

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -101,15 +101,22 @@ export class WorkbookPage extends Resource {
       elem.tagName = 'a';
 
       // Type 1: page attr points to another page
-      // Type 2: page attr points to another page, idref to an item within that page (and we ignore it)
-      if (hasPage) {
+      if (hasPage && !idref) {
         $(elem).attr('idref', pageValue);
         $(elem).removeAttr('page');
         page.unresolvedReferences.push(pageValue);
+      } else if (hasPage && idref) {
+        // Type 2: page attr points to another page, idref to an item within that page
+        $(elem).attr('idref', pageValue);
+        $(elem).attr('anchor', idref); // Store the idref as an anchor for future use, but it'll be ignored in torus for now.
+        $(elem).removeAttr('page');
+        page.unresolvedReferences.push(pageValue);
+
         // Type 3: idref points to content item on this page so make a link to this page.
         //         Should we just remove the link since we don't have capability to link to items on the page in torus?
       } else if (!hasPage && hasIdref) {
         $(elem).attr('idref', $('workbook_page').attr('id'));
+        $(elem).attr('anchor', idref); // Store the idref as an anchor for future use, but it'll be ignored in torus for now.
       }
     });
 

--- a/test/content/x-oli-workbook_page/links-test.xml
+++ b/test/content/x-oli-workbook_page/links-test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC " -//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page id="p1_changes_enthalpy" xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/"
+    xmlns:bib="http://bibtexml.sf.net/" xmlns:pref="http://oli.web.cmu.edu/preferences/"
+    xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:theme="http://oli.web.cmu.edu/presentation/"
+    xmlns:wb="http://oli.web.cmu.edu/activity/workbook/">
+
+
+    <head>
+        <title>Links test page</title>
+        <objref idref="enthalpy" />
+    </head>
+
+    <body>
+        <p>
+            <activity_link idref="Periodic_Table" target="new">
+                <em>Reference: The Periodic Table of Elements</em>
+            </activity_link>
+        </p>
+        <p>
+            <xref idref="link1id" page="link1page">Link 1</xref>
+            <xref idref="link2id">Link 2</xref>
+        </p>
+
+        <image id="c64f2185fc194a5da0b1c6c1885d50b8" src="../webcontent/1x1.png" alt=""
+            style="inline" vertical-align="middle">
+            <caption> Here is a caption with a <xref idref="link3id" page="link3page">Link 3</xref>
+            </caption>
+        </image>
+
+    </body>
+</workbook_page>

--- a/test/links-test.ts
+++ b/test/links-test.ts
@@ -46,6 +46,15 @@ describe('rename links', () => {
     expect(caption[1].page).toBeUndefined();
   });
 
+  test('should store the ignored idref in anchor', () => {
+    const content = results[0].content.model[0].children;
+    const [, p2, img] = content;
+    const caption = img.caption;
+    expect(p2.children[1].anchor).toBe('link1id');
+    expect(caption[1].anchor).toBe('link3id');
+    expect(p2.children[3].anchor).toEqual('link2id');
+  });
+
   test('should maintain idref in activity_links', () => {
     const content = results[0].content.model[0].children;
     const [p1] = content;

--- a/test/links-test.ts
+++ b/test/links-test.ts
@@ -1,0 +1,76 @@
+import { MediaSummary } from 'src/media';
+import { ProjectSummary } from 'src/project';
+import { WorkbookPage } from 'src/resources/workbook';
+
+const mediaSummary: MediaSummary = {
+  mediaItems: {},
+  missing: [],
+  urlPrefix: '',
+  downloadRemote: false,
+  flattenedNames: {},
+};
+
+const projectSummary = new ProjectSummary('', '', '', mediaSummary);
+
+describe('rename links', () => {
+  let results: any = {};
+
+  beforeAll(async () => {
+    return new WorkbookPage(
+      './test/content/x-oli-workbook_page/links-test.xml',
+      true
+    )
+      .convert(projectSummary)
+      .then((r) => {
+        results = r;
+      });
+  });
+
+  test('should rename xref and activity_link to a', () => {
+    const content = results[0].content.model[0].children;
+    const [p1, p2, img] = content;
+    const caption = img.caption;
+    expect(p1.children[1].type).toEqual('a'); // activity_link gets renamed to a
+    expect(p2.children[1].type).toEqual('a'); // xref gets renamed to a
+    expect(p2.children[3].type).toEqual('a'); // xref gets renamed to a
+    expect(caption[1].type).toEqual('a'); // xref gets renamed to a
+  });
+
+  test('should not have page attributes', () => {
+    const content = results[0].content.model[0].children;
+    const [p1, p2, img] = content;
+    const caption = img.caption;
+    expect(p1.children[1].page).toBeUndefined();
+    expect(p2.children[1].page).toBeUndefined();
+    expect(p2.children[3].page).toBeUndefined();
+    expect(caption[1].page).toBeUndefined();
+  });
+
+  test('should maintain idref in activity_links', () => {
+    const content = results[0].content.model[0].children;
+    const [p1] = content;
+    expect(p1.children[1].idref).toEqual('Periodic_Table');
+  });
+
+  test('should move page to idref in xref', () => {
+    const content = results[0].content.model[0].children;
+    const [, p2, img] = content;
+    const caption = img.caption;
+    expect(p2.children[1].idref).toEqual('link1page'); // Make sure the page attribute got moved into idref
+    expect(caption[1].idref).toEqual('link3page'); // Make sure the page attribute got moved into idref inside captions
+  });
+
+  test("should move current page to idref if there's no page attribute", () => {
+    const content = results[0].content.model[0].children;
+    const [, p2] = content;
+    expect(p2.children[3].idref).toEqual('p1_changes_enthalpy'); // The current page should end up in idref if there is no page attribute
+  });
+
+  test('page should have all unresolved idrefs', () => {
+    // Make sure it contains all the ids: 'link1page', 'link3page', 'Periodic_Table', 'link1page', 'p1_changes_enthalpy', 'link3page'
+    expect(results[0].unresolvedReferences).toContain('link1page');
+    expect(results[0].unresolvedReferences).toContain('link3page');
+    expect(results[0].unresolvedReferences).toContain('Periodic_Table');
+    expect(results[0].unresolvedReferences).toContain('link1page');
+  });
+});


### PR DESCRIPTION
Torus expects all links to be of {type: 'a'}, previously the digest tool was passing {type: 'xref} which would not display in a torus page correctly. This change converts those `xref` into `a` links, and handles a mismatch in content models. Some rules:

1. An xref with a page attribute will have the resulting `a` link with an idref pointing to that page.
2. An xref with an idref attribute will have the resulting `a` link with an anchor pointing to the idref. Currently, this is ignored in torus, but will be ingested and maintained if the link is edited.
3. An xref without a page attribute, will have it's idref set to the current page. This is an unfortunate case since the link won't do anything until we start supporting the anchor attribute.

In all these cases, the `target` attribute is now passed an maintained in torus.

To test this end to end, you need the torus changes here: https://github.com/Simon-Initiative/oli-torus/pull/3705

Fixes https://github.com/Simon-Initiative/oli-torus/issues/3536
