### PR TITLE
[Bugfix] Use textarea instead of text for short answer

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -332,7 +332,7 @@ function single_response_text(question: any) {
 
   return {
     stem: Common.buildStem(question),
-    inputType: 'text',
+    inputType: 'textarea',
     submitAndCompare: Common.isSubmitAndCompare(question),
     authoring: {
       parts: [Common.buildTextPart(Common.getPartIds(question)[0], question)],

--- a/test/resources/feedback-test.ts
+++ b/test/resources/feedback-test.ts
@@ -683,7 +683,7 @@ describe('convert feedback', () => {
               },
             ],
           },
-          inputType: 'text',
+          inputType: 'textarea',
           submitAndCompare: false,
           authoring: {
             parts: [


### PR DESCRIPTION
Converts the short_answer inputs from using a text input to a textarea input by default on import.

Before:
![image](https://github.com/Simon-Initiative/course-digest/assets/333265/96a6d656-6fdd-4d48-be9a-2a0e3336aa83)

After:
![image](https://github.com/Simon-Initiative/course-digest/assets/333265/46009626-e892-4894-86d1-b7d4226cc398)

As far as I can tell, they're always supposed to be a texarea. I couldn't find a way of specifying it inside echo, and didn't see anything in the DTD to suggest there was an option for different input types. I'm not 100% confident in that conclusion.

Note: the button text is different in torus, so we'll have to edit the lessons to refer to the correct wording.

Fixes https://github.com/Simon-Initiative/oli-torus/issues/3638