### PR TITLE
[MER-2203] Normalizers are causing subscripts to be pushed onto newline

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -171,6 +171,18 @@ export function standardContentManipulations($: any) {
     }
   });
 
+  $('caption').each((i: any, item: any) => {
+    const containsInlineOnly = item.children.every(
+      (c: any) =>
+        c.type === 'text' || (c.type == 'tag' && DOM.isInlineTag(c.name))
+    );
+
+    // We must wrap these inlines only in a paragraph
+    if (containsInlineOnly) {
+      $(item).html(`<p>${$(item).html()}</p>`);
+    }
+  });
+
   // Inline images should technically be valid in any Slate model element
   // that supports inline elements, but we're only explicitly handling
   // converting images in paragraphs and links (anchors).

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -122,6 +122,7 @@ const inlineTags = {
   term: true,
   extra: true,
   text: true,
+  xref: true,
 };
 
 export function isInlineTag(tag: string) {

--- a/test/img-caption-test.ts
+++ b/test/img-caption-test.ts
@@ -1,0 +1,31 @@
+import * as cheerio from 'cheerio';
+import { standardContentManipulations } from 'src/resources/common';
+
+describe('standardContentManipulations', () => {
+  it('should wrap inline img captions in a paragraph', () => {
+    const $ = cheerio.load(
+      `<body>
+        <img src="https://example.com/image.png" alt="alt text">
+            <caption>Some Text<sub>subtext</sub> here.</caption>        
+        </img>
+    </body>`,
+      {
+        normalizeWhitespace: true,
+        xmlMode: true,
+      }
+    );
+
+    standardContentManipulations($);
+
+    expect($('caption').children().length).toBe(1); // A single p child
+    expect(($('caption').children().first()[0] as any).tagName).toBe('p');
+
+    expect($('caption').children().first().text()).toBe(
+      'Some Textsubtext here.'
+    ); // With text unaltered
+
+    expect($('caption').html()).toBe(
+      '<p>Some Text<em style="sub">subtext</em> here.</p>'
+    );
+  });
+});

--- a/test/links-test.ts
+++ b/test/links-test.ts
@@ -33,7 +33,7 @@ describe('rename links', () => {
     expect(p1.children[1].type).toEqual('a'); // activity_link gets renamed to a
     expect(p2.children[1].type).toEqual('a'); // xref gets renamed to a
     expect(p2.children[3].type).toEqual('a'); // xref gets renamed to a
-    expect(caption[1].type).toEqual('a'); // xref gets renamed to a
+    expect(caption[0].children[1].type).toEqual('a'); // xref gets renamed to a
   });
 
   test('should not have page attributes', () => {
@@ -43,7 +43,7 @@ describe('rename links', () => {
     expect(p1.children[1].page).toBeUndefined();
     expect(p2.children[1].page).toBeUndefined();
     expect(p2.children[3].page).toBeUndefined();
-    expect(caption[1].page).toBeUndefined();
+    expect(caption[0].children[1].page).toBeUndefined();
   });
 
   test('should store the ignored idref in anchor', () => {
@@ -51,7 +51,7 @@ describe('rename links', () => {
     const [, p2, img] = content;
     const caption = img.caption;
     expect(p2.children[1].anchor).toBe('link1id');
-    expect(caption[1].anchor).toBe('link3id');
+    expect(caption[0].children[1].anchor).toBe('link3id');
     expect(p2.children[3].anchor).toEqual('link2id');
   });
 
@@ -61,12 +61,12 @@ describe('rename links', () => {
     expect(p1.children[1].idref).toEqual('Periodic_Table');
   });
 
-  test('should move page to idref in xref', () => {
+  test('should move page to idref in xref in captions', () => {
     const content = results[0].content.model[0].children;
     const [, p2, img] = content;
     const caption = img.caption;
     expect(p2.children[1].idref).toEqual('link1page'); // Make sure the page attribute got moved into idref
-    expect(caption[1].idref).toEqual('link3page'); // Make sure the page attribute got moved into idref inside captions
+    expect(caption[0].children[1].idref).toEqual('link3page'); // Make sure the page attribute got moved into idref inside captions
   });
 
   test("should move current page to idref if there's no page attribute", () => {


### PR DESCRIPTION
Image captions have their own slate sub-editor, so the content in those captions must follow the document-level normalization rules we have in place. 

Before, a caption might contain multiple inline elements such as:
`caption: [ {text:"hello"}, {text: "world"} ]`

Now, those will get wrapped up into a paragraph.
`caption: [ {type: 'p', children:[{text:"hello"}, {text: "world"} ]]`

This fixes an issue in chemistry import causing subscript text having extra linebreaks.

Before:
![image](https://github.com/Simon-Initiative/course-digest/assets/333265/4aedb20a-9c12-478b-a6cc-6eb4e01ab715)

After:
![image](https://github.com/Simon-Initiative/course-digest/assets/333265/55fc15db-4aff-46df-aab3-f23b671b161c)


Before:
![image](https://github.com/Simon-Initiative/course-digest/assets/333265/3a78a047-1fda-4d2d-89bc-fafb60f44acd)

After:
![image](https://github.com/Simon-Initiative/course-digest/assets/333265/131eb2b6-552b-4954-ac9a-76ab8ed12640)

