### PR TITLE
[Bugfix] Handle mixed block and inline content in submit & compare feedback

### DIFF
--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -120,34 +120,12 @@ export function isBlankText(e: any): boolean {
   return e && e.text !== undefined && e.text.trim().length === 0;
 }
 
-export function collectTextsIntoParagraphs(children: any) {
-  const result = [];
-  let successiveTexts: any[] = [];
-  children.forEach((c: any) => {
-    if (c.text !== undefined || isInlineTag(c.type)) {
-      successiveTexts.push(c);
-    } else {
-      // hit non-text: finish any pending paragraph and reset
-      if (successiveTexts.length > 0) {
-        result.push({ type: 'p', children: successiveTexts });
-        successiveTexts = [];
-      }
-      result.push(c);
-    }
-  });
-  // finish any final pending paragraph
-  if (successiveTexts.length > 0) {
-    result.push({ type: 'p', children: successiveTexts });
-  }
-  return result;
-}
-
 export function wrapLooseText(children: any, trace = false) {
   // if loose text pieces alongside blocks, strip spurious blank ones,
   // collecting successive non-blank text pieces into p's.
   if (children.length > 1) {
     if (children.some((b: any) => XML.isBlockElement(b.type))) {
-      const result = collectTextsIntoParagraphs(
+      const result = wrapInlinesWithParagraphs(
         children.filter((c: any) => !isBlankText(c))
       );
 
@@ -158,11 +136,9 @@ export function wrapLooseText(children: any, trace = false) {
         console.log('wrapText in:' + JSON.stringify(children, null, 2));
         console.log('wrapText out:' + JSON.stringify(result, null, 2));
       }
-
       return result;
     }
   }
-
   return children;
 }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -123,6 +123,7 @@ const inlineTags = {
   extra: true,
   text: true,
   xref: true,
+  img_inline: true,
 };
 
 export function isInlineTag(tag: string) {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -124,6 +124,8 @@ const inlineTags = {
   text: true,
   xref: true,
   img_inline: true,
+  input_ref: true,
+  formula_inline: true,
 };
 
 export function isInlineTag(tag: string) {

--- a/test/content/x-oli-inline-assessment/feedback-formatting.xml
+++ b/test/content/x-oli-inline-assessment/feedback-formatting.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Inline Assessment MathML 1.4//EN" "http://oli.web.cmu.edu/dtd/oli_inline_assessment_mathml_1_4.dtd">
+<?xml-stylesheet type="text/css" href="http://oli.web.cmu.edu/authoring/oxy-author/oli_inline_assessment_1_1.css"?>
+<assessment id="isotope_atomic_mass_2_lbd">
+    <title>tutor</title>
+    <page>
+        <question id="q3">
+
+            <body>Potassium has an atomic mass of 39.098 amu. This element has 3 naturally occurring
+                isotopes: K−39, K−40, and K−41. Without doing any calculations and without any
+                additional information, what can you conclude about the relative abundances of these
+                three isotopes of potassium?</body>
+            <short_answer id="qsub_0" />
+            <part id="qpart_0">
+                <response input="qsub_0" match="*" score="10" />
+                <hint>The atomic mass on the periodic table are calculated based on the percent
+                    abundance of each isotope. </hint>
+                <hint>Isotopes with greater percent abundance contribute more to the atomic mass
+                    than those with a lesser percent abundance.</hint>
+                <explanation>Because the atomic mass on the periodic table is very close to 39, you
+                    can conclude that the most abundant of the 3 isotopes is K-39. <p>In fact the
+                    percent abundances are: K-39 is 93.3%. K-41 is 6.7%. K-40 is 0.012%. </p> It is
+                    common that elements have one isotope that is far more abundant than the other
+                    (although not always the case). If the atomic mass on the periodic table is very
+                    close to a whole number, it is safe to assume that if you rounded that value to
+                    the nearest whole number you would have the mass number of the most common
+                    isotope for that element. Like we see with potassium.</explanation>
+            </part>
+        </question>
+    </page>
+
+</assessment>

--- a/test/wrap-inlines-test.ts
+++ b/test/wrap-inlines-test.ts
@@ -1,0 +1,111 @@
+import { MediaSummary } from 'src/media';
+import { ProjectSummary } from 'src/project';
+import { Formative } from 'src/resources/formative';
+import { wrapInlinesWithParagraphs } from 'src/resources/questions/common';
+
+const mediaSummary: MediaSummary = {
+  mediaItems: {},
+  missing: [],
+  urlPrefix: '',
+  downloadRemote: false,
+  flattenedNames: {},
+};
+
+const projectSummary = new ProjectSummary('', '', '', mediaSummary);
+
+describe('wrapInlinesWithParagraphs', () => {
+  it('should return an empty array if the input is empty', () => {
+    const input: any[] = [];
+    const result = wrapInlinesWithParagraphs(input);
+    expect(result).toEqual([]);
+  });
+
+  it('should wrap a single text node', () => {
+    const input = [{ text: 'text' }];
+    const result = wrapInlinesWithParagraphs(input);
+    expect(result).toEqual([
+      {
+        type: 'p',
+        children: [{ text: 'text' }],
+      },
+    ]);
+  });
+
+  it('should wrap multiple text nodes in single p', () => {
+    const input = [{ text: 'text1' }, { text: 'text2' }];
+    const result = wrapInlinesWithParagraphs(input);
+    expect(result).toEqual([
+      {
+        type: 'p',
+        children: [{ text: 'text1' }, { text: 'text2' }],
+      },
+    ]);
+  });
+
+  it('should wrap multiple text on either side of block', () => {
+    const input = [
+      { text: 'text1' },
+      { text: 'text2' },
+      { type: 'p' },
+      { text: 'text3' },
+      { text: 'text4' },
+    ];
+    const result = wrapInlinesWithParagraphs(input);
+    expect(result).toEqual([
+      {
+        type: 'p',
+        children: [{ text: 'text1' }, { text: 'text2' }],
+      },
+      { type: 'p' },
+      {
+        type: 'p',
+        children: [{ text: 'text3' }, { text: 'text4' }],
+      },
+    ]);
+  });
+
+  it('should wrap other inlines', () => {
+    const input = [
+      { text: 'text1' },
+      { type: 'img_inline', src: 'src' },
+      { type: 'sup', children: [{ text: 'sup text' }] },
+      { type: 'p' },
+      { text: 'text3' },
+      { text: 'text4' },
+    ];
+    const result = wrapInlinesWithParagraphs(input);
+    expect(result).toEqual([
+      {
+        type: 'p',
+        children: [
+          { text: 'text1' },
+          { type: 'img_inline', src: 'src' },
+          { type: 'sup', children: [{ text: 'sup text' }] },
+        ],
+      },
+      { type: 'p' },
+      {
+        type: 'p',
+        children: [{ text: 'text3' }, { text: 'text4' }],
+      },
+    ]);
+  });
+
+  it('should wrap individual text nodes', () => {
+    return new Formative(
+      './test/content/x-oli-inline-assessment/feedback-formatting.xml',
+      true
+    )
+      .convert(projectSummary)
+      .then((r: any) => {
+        console.info(
+          r[0].content.authoring.parts[0].responses[0].feedback.content
+        );
+        expect(
+          r[0].content.authoring.parts[0].responses[0].feedback.content.map(
+            (f: any) => f.type
+          )
+        ).toEqual(['p', 'p', 'p']);
+      });
+  });
+});


### PR DESCRIPTION
The reported bug was that there wasn't enough spacing between paragraphs here:

![image](https://github.com/Simon-Initiative/course-digest/assets/333265/4d165292-84c1-481b-93cd-9228c63ecc76)

Upon investigation, I found that the content in that feedback consisted of a text node, a paragraph, and a text node. That is not valid slate-js content.  

_Side Note: upon opening it in authoring, the content would get normalized and fixed if the user made any change whatsoever to the page._

The feedback was being passed through `ensureParagraphs` in questions/common.ts which I think was meant to prevent things like this, but `ensureParagraphs` only catches the case where all the children are inline, not when they're partially inline and partially block elements.

In this PR, there is a new `wrapInlinesWithParagraphs` that handles any combination of inline & block elements, wrapping all the inline, and keeping adjacent inlines in the same paragraph, but that's only used in one very specific case. It technically fixes this bug, and in the most surgical way possible.

If we were early in the process, I would advocate for swapping out  the implementation of ensureParagraphs with wrapInlinesWithParagraphs for all content.

But when I tried that, it resulted in over 14,000 changes in the chemistry course. The chances of this causing unexpected content changes is a near certainty.

A few options on where to go next:

1. Only apply this new method as surgically as possible like this PR does as issues come up.
2. Apply this more broadly, but selectively. Such as to all feedback, all hints, or some subset of elements.
3. Apply it everywhere, and deal with the consequences.


