### PR TITLE
[Feature] Maintain iframe width/height

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -171,6 +171,8 @@ export function standardContentManipulations($: any) {
     }
   });
 
+  stripEmptyCaptions($, 'iframe');
+
   $('caption').each((i: any, item: any) => {
     const containsInlineOnly = item.children.every(
       (c: any) =>
@@ -222,7 +224,7 @@ export function standardContentManipulations($: any) {
 
   // iframe and youtube are both designed to scale responsively within Torus, so
   // we need to strip out height and width attrs if they exist
-  stripMediaSizing($, 'iframe');
+  stripNonDefaultMediaSizing($, 'iframe');
   stripMediaSizing($, 'youtube');
 
   DOM.stripElement($, 'p ol');
@@ -327,6 +329,44 @@ function handleCommandButtons($: any) {
   // paragraphs inside of list-items, but downstream code eliminates those
   // conditions.
   $('command_button').wrap('<p></p>');
+}
+
+// We don't want empty caption tags ie <caption /> to be expanded to an empty caption with <p></p> in it for iframes (maybe others?)
+// This will remove those before they get expanded
+function stripEmptyCaptions($: any, selector: string) {
+  $(selector).each((i: any, item: any) => {
+    const caption = $(item).find('caption');
+    if (caption !== undefined) {
+      const noText = caption.text().trim() === '';
+      const noChildren = caption.children().length === 0;
+      if (noText && noChildren) {
+        // This is an empty <caption /> node, trash it.
+        caption.remove();
+      }
+    }
+  });
+}
+
+// Strip any sizing that's not the default 800x450 that iframes use
+// The thinking is that if the author has specified a size, they want
+// that size, and we shouldn't override it.  However, if they haven't
+// specified a size and left the default, we want to use the default torus
+// size.
+function stripNonDefaultMediaSizing(
+  $: any,
+  selector: string,
+  width = 800,
+  height = 450
+) {
+  $(selector).each((i: any, item: any) => {
+    if (
+      $(item).attr('width') === width.toString() &&
+      $(item).attr('height') === height.toString()
+    ) {
+      $(item).removeAttr('height');
+      $(item).removeAttr('width');
+    }
+  });
 }
 
 function stripMediaSizing($: any, selector: string) {

--- a/test/content/x-oli-workbook_page/iframes.xml
+++ b/test/content/x-oli-workbook_page/iframes.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workbook_page PUBLIC "-//Carnegie Mellon University//DTD Workbook Page MathML 3.8//EN" "http://oli.web.cmu.edu/dtd/oli_workbook_page_mathml_3_8.dtd">
+<workbook_page xmlns:bib="http://bibtexml.sf.net/"
+    xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/"
+    xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:pref="http://oli.web.cmu.edu/preferences/"
+    xmlns:theme="http://oli.web.cmu.edu/presentation/"
+    xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="f9dc05d74fbc4e219d2a8bace8e09997">
+    <head>
+        <title>New Page</title>
+    </head>
+    <body>
+        <iframe id="1" src="https://www.example.com">
+            <cite id="5" />
+            <caption />
+            <popout enable="false"></popout>
+        </iframe>
+        <iframe id="2" src="https://www.example.com" height="450"
+            width="800">
+            <cite id="6" />
+            <caption>Here is my caption</caption>
+            <popout enable="false"></popout>
+        </iframe>
+        <iframe id="3" src="https://www.example.com" width="1000" height="600">
+            <cite id="7" />
+            <caption>
+                <p>Here <b>is</b> my caption</p>
+            </caption>
+            <popout enable="false"></popout>
+        </iframe>
+        <iframe id="4" src="https://www.example.com" width="800">
+            <cite id="7" />
+            <caption />
+            <popout enable="false"></popout>
+        </iframe>
+        <iframe id="5" src="https://www.example.com" height="450"
+            width="100%">
+            <cite id="8" />
+            <caption />
+            <popout enable="false"></popout>
+        </iframe>
+
+    </body>
+</workbook_page>

--- a/test/iframes-test.ts
+++ b/test/iframes-test.ts
@@ -1,0 +1,100 @@
+import { MediaSummary } from 'src/media';
+import { ProjectSummary } from 'src/project';
+import { WorkbookPage } from 'src/resources/workbook';
+
+const mediaSummary: MediaSummary = {
+  mediaItems: {},
+  missing: [],
+  urlPrefix: '',
+  downloadRemote: false,
+  flattenedNames: {},
+};
+
+const projectSummary = new ProjectSummary('', '', '', mediaSummary);
+
+describe('iframes', () => {
+  let results: any = {};
+
+  beforeAll(async () => {
+    return new WorkbookPage(
+      './test/content/x-oli-workbook_page/iframes.xml',
+      true
+    )
+      .convert(projectSummary)
+      .then((r) => {
+        results = r;
+      });
+  });
+
+  test('should not import empty iframe captions', () => {
+    const content = results[0].content.model[0].children;
+    const [iframe1] = content;
+    expect(iframe1.caption).toBeUndefined();
+  });
+
+  test('should import iframe caption as text', () => {
+    const content = results[0].content.model[0].children;
+    const [, iframe2] = content;
+
+    expect(iframe2.caption).toEqual([
+      {
+        type: 'p',
+        children: [{ text: 'Here is my caption' }],
+      },
+    ]);
+  });
+
+  test('should import iframe caption as rich text', () => {
+    const content = results[0].content.model[0].children;
+    const [, , iframe3] = content;
+
+    expect(iframe3.caption).toEqual([
+      {
+        type: 'p',
+        children: [
+          { text: 'Here ' },
+          {
+            type: 'b',
+            children: [{ text: 'is' }],
+          },
+          { text: ' my caption' },
+        ],
+      },
+    ]);
+  });
+
+  test('should import iframe without dimensions', () => {
+    const content = results[0].content.model[0].children;
+    const [iframe1] = content;
+    expect(iframe1.height).toBeUndefined();
+    expect(iframe1.width).toBeUndefined();
+  });
+
+  test('should not import iframe default dimensions', () => {
+    const content = results[0].content.model[0].children;
+    const [, iframe2] = content;
+    expect(iframe2.height).toBeUndefined();
+    expect(iframe2.width).toBeUndefined();
+  });
+
+  test('should import iframe with pixel dimensions', () => {
+    const content = results[0].content.model[0].children;
+    const [, , iframe3] = content;
+    expect(iframe3.height).toBe('600');
+    expect(iframe3.width).toBe('1000');
+  });
+
+  test('should import iframe with only width dimension', () => {
+    const content = results[0].content.model[0].children;
+    const [, , , iframe4] = content;
+    expect(iframe4.height).toBeUndefined();
+    expect(iframe4.width).toBe('800');
+  });
+
+  test('should import iframe with percent width dimension', () => {
+    const content = results[0].content.model[0].children;
+    const [, , , , iframe5] = content;
+    expect(iframe5.height).toBe('450');
+    expect(iframe5.width).toBe('100%');
+  });
+});


### PR DESCRIPTION
Two changes to support sizing iframes in torus

1. If iframes have an empty <caption /> tag inside them, previously it was expanded to be a caption with a single paragraph in it. Now, it's just removed and no caption is set. This is important because torus will render an extra frame around iframes with captions that throws off the intended alignment/sizing from legacy courses.
2. Iframes where the author has specified a size (ie. it's not the default echo iframe size) will have that size exported. In the case where the iframe is set to 800x450, the default echo size, no size is exported. The thinking is the author didn't set a size and wanted to use the default, and torus has it's own default to use.