### PR TITLE
[BUGFIX] handle wildcard pool selection[MER-2324]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,7 @@ export function convertAction(options: CmdOptions): Promise<ConvertedResults> {
 
           updated = Convert.updateDerivativeReferences(updated);
           updated = Convert.generatePoolTags(updated);
+          updated = Convert.fixWildcardSelections(updated);
           updated = filterOutTemporaryContent(updated);
           updated = Convert.updateNonDirectImageReferences(
             updated,

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -809,7 +809,9 @@ export function processAssessmentModel(
               ],
             },
           },
-          count: parseInt(item.count),
+          // for wildcard count meaning 'all in pool', enter pool tag here. Post-processing after all
+          // resources seen will replace with count of items with that tag.
+          count: item.count == '*' ? tagId : parseInt(item.count),
           id: guid(),
         } as any;
 


### PR DESCRIPTION
Tool was not handling legacy wildcard pool selection notation (count="*") used to select every item from a pool and the result in this case was causing crash on use after ingestion. This handles wildcard selection by putting in count of items in the pool. Accomplished by a post-processing step done after all resources have been seen.