### PR TITLE
[BUGFIX] handle pullout type [MER-2162]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -457,7 +457,6 @@ function main() {
   dotenv.config();
 
   const options = commandLineArgs(optionDefinitions) as CmdOptions;
-  console.log('options.webContentBundle = ' + options.webContentBundle);
 
   if (validateArgs(options)) {
     if (options.operation === 'summarize') {

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -261,6 +261,15 @@ export function standardContentManipulations($: any) {
   );
 
   DOM.rename($, 'composite_activity', 'group');
+
+  DOM.renameAttribute($, 'pullout', 'type', 'pullouttype');
+  $('pullout[pullouttype]').each((i: number, item: any) => {
+    const typeId = $(item).attr('pullouttype');
+    const typeHeader = capitalize(
+      typeId === 'tosumup' ? 'To Sum Up' : capitalize(typeId)
+    );
+    $(item).prepend(`<em>${typeHeader}...</em>`);
+  });
   DOM.rename($, 'pullout title', 'p');
   DOM.rename($, 'pullout', 'group');
 

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -265,9 +265,7 @@ export function standardContentManipulations($: any) {
   DOM.renameAttribute($, 'pullout', 'type', 'pullouttype');
   $('pullout[pullouttype]').each((i: number, item: any) => {
     const typeId = $(item).attr('pullouttype');
-    const typeHeader = capitalize(
-      typeId === 'tosumup' ? 'To Sum Up' : capitalize(typeId)
-    );
+    const typeHeader = typeId === 'tosumup' ? 'To Sum Up' : capitalize(typeId);
     $(item).prepend(`<em>${typeHeader}...</em>`);
   });
   DOM.rename($, 'pullout title', 'p');


### PR DESCRIPTION
Pullouts can have a "type" field. Possible values include "tosumup" (To Sum Up). The pullout type attribute was not getting renamed, leading to undefined content element errors on ingestion. 

In legacy, the type label is printed in bold followed by ellipses ("To Sum Up...") as a prefix to the pullout content, so this PR implements a version of that.

There are other divergences from legacy pullout behavior that are not addressed: 

-  In legacy, typed pullouts are formatted differently than untyped (untyped render entirely in italics); 
-  legacy merges type label as prefix into first pullout block (title or text content) rather than as header; and 
-   legacy pullouts are indented like block quotes (torus issue [#3659](https://github.com/Simon-Initiative/oli-torus/issues/3659)) -- this is what makes them 'pullouts' - while migration tool just turns them into paragraphs aligned with the preceding and following paragraphs so they are not set off.

But this gets past the error-causing handling of the type field and gets the pullout content w/label on the page in readable form. 