### PR TITLE
[BUGFIX] Preserve whitespace in feedback within pools [MER-2482]

### DIFF
--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -26,10 +26,21 @@ export class Pool extends Resource {
     const xml = $.html();
     return new Promise((resolve, _reject) => {
       XML.toJSON(xml, projectSummary, {
+        // use same list as formative
         p: true,
         em: true,
         li: true,
         td: true,
+        choice: true,
+        stem: true,
+        hint: true,
+        feedback: true,
+        explanation: true,
+        material: true,
+        anchor: true,
+        translation: true,
+        dt: true,
+        dd: true,
       }).then((r: any) => {
         const items: any = [];
 


### PR DESCRIPTION
XML.toJSON takes a list of elements within which to preserve whitespace. This call is duplicated for different document types. Pool processing was not setting the flag within question elements like feedback (also hints, choices, stems). That causes spaces before or after styled text (for example italicized) not wrapped in a paragraph to get dropped at this point. This was seen on feedback using italicized pieces. 

This changes to pass the same list of elements when processing pools as is used for formatives, on the theory that the same elements could occur in both places,  That possibly includes more than is needed, but safe. 