### PR TITLE
[BUGFIX]  URL mismatch when special chars in filenames [MER-2514]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ const optionDefinitions = [
   { name: 'mediaUrlPrefix', type: String, alias: 'p' },
   { name: 'spreadsheetPath', type: String, alias: 's' },
   { name: 'svnRoot', type: String },
-  { name: 'downloadRemote', type: Boolean },
+  { name: 'downloadRemote', type: Boolean, alias: 'r' },
   { name: 'quiet', type: Boolean, alias: 'q' },
   { name: 'mergePathA', type: String, alias: 'a' },
   { name: 'mergePathB', type: String, alias: 'b' },

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -269,7 +269,7 @@ export function standardContentManipulations($: any) {
     $(item).prepend(`<em>${typeHeader}...</em>`);
   });
   DOM.rename($, 'pullout title', 'p');
-  DOM.rename($, 'pullout', 'group');
+  DOM.rename($, 'pullout', 'callout');
 
   $('example').each((i: any, item: any) => {
     $(item).attr('purpose', 'example');

--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -26,10 +26,21 @@ export class Pool extends Resource {
     const xml = $.html();
     return new Promise((resolve, _reject) => {
       XML.toJSON(xml, projectSummary, {
+        // use same list as formative
         p: true,
         em: true,
         li: true,
         td: true,
+        choice: true,
+        stem: true,
+        hint: true,
+        feedback: true,
+        explanation: true,
+        material: true,
+        anchor: true,
+        translation: true,
+        dt: true,
+        dd: true,
       }).then((r: any) => {
         const items: any = [];
 


### PR DESCRIPTION
If a source filename has special characters like the combining tilde used in Spanish, migration tool will generate and record a URL-encoded URL for it. For example, señora.jpg => `sen%CC%83ora.jpg` where CC 83 is the UTF-8 encoding of the combining tilde. However, the Amazon S3 API apparently takes a **non**-URL-encoded "key" which may be any UTF-8 string. Including special characters may cause trouble for client applications, but is allowed in an S3 key. 

The upload tool was generating a key from the _encoded_ URL. The result in the above case is that the URL needed to access the uploaded file would be `sen%25CC%2583ora.jpg` to match the literal percent characters in the S3 key (and this was the value returned from the API as the data.location). So the generated URLs fail to match the resulting upload location of the file whenever characters requiring URL-encoding are part of the filename.

This changes the code to undo URL encoding when forming the S3 key. 