### PR TITLE
[BUGFIX] upload w/non-Url-encoded S3 key to avoid url mismatches [MER-2514]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ const optionDefinitions = [
   { name: 'mediaUrlPrefix', type: String, alias: 'p' },
   { name: 'spreadsheetPath', type: String, alias: 's' },
   { name: 'svnRoot', type: String },
-  { name: 'downloadRemote', type: Boolean },
+  { name: 'downloadRemote', type: Boolean, alias: 'r' },
   { name: 'quiet', type: Boolean, alias: 'q' },
   { name: 'mergePathA', type: String, alias: 'a' },
   { name: 'mergePathB', type: String, alias: 'b' },


### PR DESCRIPTION
If a source filename has characters requiring URL-encoding, such as the combining tilde used in Spanish, migration tool will generate and record a suitable URL-encoded URL for it. For example, `señora.jpg` => `sen%CC%83ora.jpg `where CC 83 is the UTF-8 encoding of the combining tilde.

However, the Amazon S3 API apparently takes a **non**-URL-encoded key which may be any UTF-8 string. (Including special characters may cause trouble for client applications, but is not forbidden in an S3 key).

The upload tool was generating the key from the path part of encoded URL. The result in the above case is that the key includes literal % characters, and the URL-encoded URL needed to access the uploaded file would in fact be `sen%25CC%2583ora.jpg`, using %25 to match the literal percent characters in the S3 key. This was indeed the value returned from the AWS API as the data.location. So the generated URLs put in the content fail to match the resulting upload location of the file whenever characters requiring URL-encoding are part of the filename.

In shorter terms, the javascript API does not expect key values to be passed URL-encoded. This changes the code to undo URL encoding when forming the S3 key for upload from the URL.