### PR TITLE
[ENHANCEMENT] strip id qualifiers from DND stylesheets [MER-2518]

### DIFF
--- a/src/resources/questions/custom-dnd.ts
+++ b/src/resources/questions/custom-dnd.ts
@@ -207,7 +207,7 @@ function fixStyles(styles: string, targetHtml: string): string {
     Array.from(new Set(styles.match(regex)))
       // leave ids used as element ids in the target html
       .filter((id) => !targetHtml.includes(`id="${id.substr(1)}`))
-      .reduce((acc, id) => (acc = replaceAll(acc, id, '')), styles)
+      .reduce((acc, id) => replaceAll(acc, id, ''), styles)
       // also remove the "all: initial" style since it causes problems
       .replace('all: initial;', '')
   );

--- a/src/resources/questions/custom-dnd.ts
+++ b/src/resources/questions/custom-dnd.ts
@@ -2,7 +2,6 @@ import * as Common from './common';
 import * as cheerio from 'cheerio';
 import * as DOM from '../../utils/dom';
 import { replaceAll } from '../../utils/common';
-import { listenerCount } from 'events';
 
 export type CustomTagDetails = {
   question: any;


### PR DESCRIPTION
The Drag-and-Drops in the PC Hardware family of courses include stylesheets using element-id-qualified styles of the form

```
#dpch01_lbd08 table, #dpch01_lbd08 th, #dpch01_lbd08 td {
                border: 1px solid black;
                text-align:center;
                vertical-align:middle;
            }
```

These ids are not used on any parent element in the torus implementation, so these styles have no effect, preventing the implementation from working at all (b/c target table cells wind up having zero height.)

Rather than force author to fix all occurrences, this has digest tool detect and strip these ids from stylesheets. 

Note detection by regex match relies on heuristic, the presence of an underscore, to distinguish ids from hex color specs of the form #ffe that may also occur within the stylesheet string. This is good enough for the cases we have to deal with, which follow this naming convention.

Also strips "all: initialize" which same stylesheets often included since it causes problems. 



