### PR TITLE
[ENHANCEMENT] detect & replace image refs in DND initiators [MER-2519]

### DIFF
--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -118,6 +118,7 @@ export interface Page extends TorusResource {
 export type NonDirectImageReference = {
   originalReference: string;
   assetReference: string;
+  location: 'styles' | 'initiators';
 };
 
 export interface Activity extends TorusResource {


### PR DESCRIPTION
PCHW course uses DNDs in which draggables ('initiators') are images, not text. Digest tool was not processing image references in the initiator section, so these images were not getting included in the media library and relative references to webcontent were not rewritten. This change adds this processing for image references in the initiator section of a custom drag and drop parallel to the handling already done for image refs in the DND style sheet.