### PR TITLE
 [ENHANCEMENT] Detect & replace image refs in DND initiators [MER-2519]

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -8,8 +8,8 @@ import * as tmp from 'tmp';
 const fetch = require('sync-fetch');
 import { Activity, NonDirectImageReference } from './resources/resource';
 import {
-  replaceImageReferences,
-  replaceInitiatorImages,
+  replaceImageRefsInStyles,
+  replaceImageRefsInInitiators,
 } from './resources/questions/custom-dnd';
 import { pathToBundleUrl } from './resources/webcontent';
 
@@ -323,14 +323,17 @@ export function transformToFlatDirectoryURLReferences(
     // Update the URL in the XML DOM
     if (url !== null) {
       if (location === 'styles')
-        styles = replaceImageReferences(styles, originalReference, url);
+        styles = replaceImageRefsInStyles(styles, originalReference, url);
       else if (location === 'initiators') {
-        initiators = replaceInitiatorImages(initiators, originalReference, url);
+        initiators = replaceImageRefsInInitiators(
+          initiators,
+          originalReference,
+          url
+        );
       }
     }
   });
-  if (initiators !== activity.content.initiators)
-    console.log('replaced initiators: ' + initiators);
+
   activity.content.layoutStyles = styles;
   activity.content.initiators = initiators;
 }

--- a/src/resources/questions/custom-dnd.ts
+++ b/src/resources/questions/custom-dnd.ts
@@ -94,21 +94,16 @@ function processLayout(
     initiators: initiators,
   });
 
-  const imageReferences =
-    locateImageReferences(
+  const imageReferences = (
+    findImageRefsInStyles(
       layoutStylesTrimmed,
       baseDir + customTag.layoutFile
-    ) || [];
-  if (imageReferences.length > 0)
-    console.log(
-      'style image refs: ' + JSON.stringify(imageReferences, null, 2)
-    );
-  const imageReferences2 = locateInitiatorImages(
-    initiators,
-    baseDir + customTag.layoutFile
+    ) || []
+  ).concat(
+    findImageRefsInInitiators(initiators, baseDir + customTag.layoutFile)
   );
 
-  return [updated, imageReferences.concat(imageReferences2)];
+  return [updated, imageReferences];
 }
 
 function cutStyleTags(layout: string) {
@@ -206,7 +201,7 @@ function cleanHtml(targetArea: any) {
     .html();
 }
 
-export function replaceImageReferences(
+export function replaceImageRefsInStyles(
   styles: string,
   originalRef: string,
   url: string
@@ -218,7 +213,7 @@ export function replaceImageReferences(
   );
 }
 
-export function locateImageReferences(styles: string, layoutFilePath: string) {
+export function findImageRefsInStyles(styles: string, layoutFilePath: string) {
   const styleLines = styles.split('\n');
   const base = layoutFilePath.slice(0, layoutFilePath.lastIndexOf('/') + 1);
   const re = /url\(\"(.*)\"\)?/;
@@ -241,7 +236,10 @@ export function locateImageReferences(styles: string, layoutFilePath: string) {
     .filter((s) => s !== null);
 }
 
-function locateInitiatorImages(initiatorHtml: string, layoutFilePath: string) {
+function findImageRefsInInitiators(
+  initiatorHtml: string,
+  layoutFilePath: string
+) {
   const base = layoutFilePath.slice(0, layoutFilePath.lastIndexOf('/') + 1);
   const $ = cheerio.load(initiatorHtml);
 
@@ -262,7 +260,7 @@ function locateInitiatorImages(initiatorHtml: string, layoutFilePath: string) {
   return refs;
 }
 
-export function replaceInitiatorImages(
+export function replaceImageRefsInInitiators(
   initiators: string,
   originalRef: string,
   url: string

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -118,6 +118,7 @@ export interface Page extends TorusResource {
 export type NonDirectImageReference = {
   originalReference: string;
   assetReference: string;
+  location: 'styles' | 'initiators';
 };
 
 export interface Activity extends TorusResource {

--- a/test/resources/questions/custom-dnd-test.ts
+++ b/test/resources/questions/custom-dnd-test.ts
@@ -1,4 +1,4 @@
-import { locateImageReferences } from '../../../src/resources/questions/custom-dnd';
+import { findImageRefsInStyles } from '../../../src/resources/questions/custom-dnd';
 
 it('should locate two references', async () => {
   const layout = `
@@ -18,7 +18,7 @@ it('should locate two references', async () => {
   }
   `;
 
-  const r = locateImageReferences(layout, 'content/test/file/path/layout.xml');
+  const r = findImageRefsInStyles(layout, 'content/test/file/path/layout.xml');
   expect(r.length).toBe(1);
   expect((r[0] as any).assetReference).toBe(
     'content/test/file/path/liquid_flask.png'


### PR DESCRIPTION
PCHW course uses DNDs in which draggables ('initiators') are images, not text, and also includes images in some layout tables ('targetArea's). Digest tool was not processing image references in these locations, so these images were not getting included in the media library and relative references to webcontent were not rewritten in these sections. This change adds this processing for image references in the initiator or targetArea section of a custom drag and drop parallel to the handling already done for image refs in the DND style sheet.

