### PR TITLE
[BUGFIX] rename video type attr as for audio [MER-2560]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -294,6 +294,7 @@ export function standardContentManipulations($: any) {
   DOM.renameAttribute($, 'pronunciation', 'type', 'contenttype');
   DOM.renameAttribute($, 'video source', 'type', 'contenttype');
   DOM.renameAttribute($, 'video source', 'src', 'url');
+  DOM.renameAttribute($, 'video', 'type', 'contenttype');
 
   DOM.renameAttribute($, 'audio', 'type', 'audioType');
 


### PR DESCRIPTION
Type attribute in video elements was not getting renamed, causing it to be passed through and taken for a content element type on rendering, giving rise to error message ` unsupported content type video/mp4`. Occurs in Logic and Proofs. Apparently never noticed before because type attribute never included in other courses.

One-line fix renames attribute as for audio.