### PR TITLE
[BUGFIX] Include survey description [MER-2594]

### DIFF
--- a/src/resources/feedback.ts
+++ b/src/resources/feedback.ts
@@ -92,7 +92,7 @@ export function convertToFormative($: cheerio.Root) {
   DOM.rename($, 'questions', 'page');
   $('page').attr('id', guid());
 
-  DOM.remove($, 'feedback description');
+  DOM.rename($, 'feedback description', 'introduction');
   DOM.rename($, 'feedback', 'assessment');
 }
 

--- a/test/resources/feedback-test.ts
+++ b/test/resources/feedback-test.ts
@@ -194,10 +194,10 @@ describe('convert feedback', () => {
     const items = await convert(projectSummary, file, false);
 
     const page = items[0];
-    const activity2_likert = items[2];
-    const activity3_likert = items[3];
-    const activity4_single_response = items[4];
-    const activity5_multiple_choice = items[5];
+    const activity2_likert = items[3];
+    const activity3_likert = items[4];
+    const activity4_single_response = items[5];
+    const activity5_multiple_choice = items[6];
 
     expect(page).toEqual(
       expect.objectContaining({
@@ -215,6 +215,20 @@ describe('convert feedback', () => {
               type: 'survey',
               id: expect.any(String),
               children: [
+                {
+                  type: 'content',
+                  id: expect.any(String),
+                  children: [
+                    {
+                      type: 'p',
+                      children: [
+                        {
+                          text: ' ',
+                        },
+                      ],
+                    },
+                  ],
+                },
                 {
                   type: 'activity-reference',
                   activity_id: expect.stringContaining(


### PR DESCRIPTION
Legacy feedback [survey] description element contains introductory content, generally boilerplate like "Please answer the questions below. Your response will not be graded, but will be available for your instructor to read. Answering these questions may also shape the discussions in class." Migration tool had been deliberately deleting this element, so this content was not being shown. All surveys in chemistry, for example, migrated without this introduction, but apparently no review ever noticed or cared enough about it to report an issue. 

This changes to include description content in the survey. Feedback migration works by converting to the formative representation. The change is just to rename description to "introduction" so it behaves like introduction content in a formative.  
