### PR TITLE
[BUGFIX] some multiple choice questions in pools changed to short answer [MER-2668]

### DIFF
--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -62,7 +62,9 @@ export function convertToFormative($: any) {
   );
   $('text').each((i: any, item: any) => $(item).attr('originalType', 'text'));
 
-  DOM.rename($, 'multiple_choice', 'question');
+  // AW: this restructuring gets used on pool items which may have multiple_choice in formative
+  // form, w/no input level element, so only rename if has input element now renamed to mc_temp
+  DOM.rename($, 'multiple_choice:has(mc_temp)', 'question');
   DOM.rename($, 'ordering', 'question');
   DOM.rename($, 'short_answer', 'question');
   DOM.rename($, 'fill_in_the_blank', 'question');


### PR DESCRIPTION
Some multiple choice questions in pools get converted into short answer (textarea) questions. Seen in several cases in Logic and Proofs, which is distinctive in using inline assessments that draw from pools. 

This happens because (1) mcqs have different representations in formatives and summatives (in formatives they have no “input” level wrapping choices); (2) pool items go through the summative-to-formative conversion; but (3) if the mcq is already in the formative form, as in the L&P cases, this restructures it into a form whose type is not recognized by subsequent code. Question type detection then falls through cases ending up on short answer questions by default. 

Fix suppresses certain conversion step in case where mcq already in formative form (no input element wrapper). 