### PR TITLE
[BUGFIX] crash on rollover nested within side-by-side materials [MER-2677]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -487,7 +487,7 @@ function handleInquiry($: any) {
 }
 
 function sideBySideMaterials($: any) {
-  $('materials material').each((i: any, item: any) => {
+  $('materials > material').each((i: any, item: any) => {
     item.tagName = 'td';
   });
   $('materials').each((i: any, item: any) => {


### PR DESCRIPTION
Migration tool crashes in certain cases seen in STEM Readiness course where an `extra` element, used for rollover content, is used within side-by-side materials.  This happens when the `extra` element carries the content in the `meaning` sub-element which itself contains a `material` element. The conversion of side-by-side `materials` was reaching into the `material `element nested within the `extra` element when this needs to be left untranslated.

Fix is to limit conversion of `material` within side-by-side `materials` to immediate children. 