### PR TITLE
[BUGFIX] some multiple choice questions in pools changed to short answer [MER-2668]

### DIFF
--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -39,11 +39,9 @@ export function determineResourceType(file: string): Promise<ResourceType> {
     if (tag.indexOf('oli_skills_model') !== -1) {
       return 'Skills';
     }
-    if (
-      tag.indexOf('DTD Assessment Pool') !== -1 ||
-      tag.indexOf('pool') !== -1
-    ) {
-      return 'Pool';
+    if (tag.indexOf('pool') !== -1) {
+      // pools may use either summative or formative (inline) assessment DTD
+      return tag.includes('Inline') ? 'FormativePool' : 'Pool';
     }
     if (tag.indexOf('organization') !== -1) {
       return 'Organization';
@@ -106,7 +104,10 @@ export function create(
     return new Superactivity.Superactivity(file, navigable);
   }
   if (t === 'Pool') {
-    return new Pool.Pool(file, navigable);
+    return new Pool.Pool(file, navigable, 'Summative');
+  }
+  if (t === 'FormativePool') {
+    return new Pool.Pool(file, navigable, 'Formative');
   }
   if (t === 'Skills') {
     return new Skills.Skills(file, navigable);

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -590,8 +590,7 @@ export function determineSubType(question: any): ItemTypes {
   if (
     question.originalType !== undefined &&
     Common.getChild(question.children, 'numeric') === undefined &&
-    Common.getChild(question.children, 'text') === undefined &&
-    Common.getChild(question.children, 'fill_in_the_blank') === undefined
+    Common.getChild(question.children, 'text') === undefined
   ) {
     const parts = Common.getChildren(question.children, 'part');
 

--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -7,14 +7,27 @@ import * as XML from 'src/utils/xml';
 import { processCodeblock, processVariables } from './common';
 import { ProjectSummary } from 'src/project';
 
+export type PoolFormat = 'Summative' | 'Formative';
+
 export class Pool extends Resource {
+  poolFormat: PoolFormat = 'Summative';
+
+  constructor(
+    file: string,
+    navigable: boolean,
+    format: PoolFormat = 'Summative'
+  ) {
+    super(file, navigable);
+    this.poolFormat = format;
+  }
+
   restructurePreservingWhitespace($: any): any {
     processCodeblock($);
     processVariables($);
   }
 
   restructure($: any): any {
-    Summative.convertToFormative($);
+    if (this.poolFormat === 'Summative') Summative.convertToFormative($);
     Formative.performRestructure($);
   }
 
@@ -52,6 +65,7 @@ export class Pool extends Resource {
             let poolQuestionNumber = 1;
             item.children.forEach((c: any) => {
               if (c.type !== 'title' && c.type !== 'content') {
+                // console.log('Pool item: ' + JSON.stringify(c, null, 2));
                 const subType = Formative.determineSubType(c);
                 const pooledActivity = Formative.toActivity(
                   c,

--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -65,7 +65,6 @@ export class Pool extends Resource {
             let poolQuestionNumber = 1;
             item.children.forEach((c: any) => {
               if (c.type !== 'title' && c.type !== 'content') {
-                // console.log('Pool item: ' + JSON.stringify(c, null, 2));
                 const subType = Formative.determineSubType(c);
                 const pooledActivity = Formative.toActivity(
                   c,

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -19,6 +19,7 @@ export type ResourceType =
   | 'Organization'
   | 'Objectives'
   | 'Pool'
+  | 'FormativePool'
   | 'Formative'
   | 'Summative'
   | 'Discussion'

--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -62,7 +62,9 @@ export function convertToFormative($: any) {
   );
   $('text').each((i: any, item: any) => $(item).attr('originalType', 'text'));
 
-  DOM.rename($, 'multiple_choice', 'question');
+  // AW: this restructuring gets used on pool items which may have multiple_choice in formative
+  // form, w/no input level element, so only rename if has input element now renamed to mc_temp
+  DOM.rename($, 'multiple_choice:has(mc_temp)', 'question');
   DOM.rename($, 'ordering', 'question');
   DOM.rename($, 'short_answer', 'question');
   DOM.rename($, 'fill_in_the_blank', 'question');

--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -52,19 +52,15 @@ export function convertToFormative($: any) {
   DOM.rename($, 'essay input', 'e_temp');
   DOM.rename($, 'image_hotspot input', 'i_temp');
 
-  // For these three types, add an attr to preserve their original types, as there can
-  // be cases where will not have a input level element
-  $('fill_in_the_blank').each((i: any, item: any) =>
-    $(item).attr('originalType', 'fill_in_the_blank')
-  );
+  // For these types, input element is optional. Add attribute recording input type,
+  // so inputs of this type can be synthesized in later processing if needed.
+  // Note fill_in_the_blank must have input to contain choices
   $('numeric').each((i: any, item: any) =>
     $(item).attr('originalType', 'numeric')
   );
   $('text').each((i: any, item: any) => $(item).attr('originalType', 'text'));
 
-  // AW: this restructuring gets used on pool items which may have multiple_choice in formative
-  // form, w/no input level element, so only rename if has input element now renamed to mc_temp
-  DOM.rename($, 'multiple_choice:has(mc_temp)', 'question');
+  DOM.rename($, 'multiple_choice', 'question');
   DOM.rename($, 'ordering', 'question');
   DOM.rename($, 'short_answer', 'question');
   DOM.rename($, 'fill_in_the_blank', 'question');


### PR DESCRIPTION
This is a more general and robust solution to MER-2668, needed to handle additional cases like fill-in-the-blank. The fix is to detect and store the pool format (dtd) and suppress summative-to-formative conversion for formative-format pools. 

MEr-2668: Some multiple choice and fill_in_the_blank questions in pools were getting converted into short answer (textarea) questions. Seen in several cases in Logic and Proofs, which is distinctive in using inline assessments that draw from pools.

This happened because (1) questions have different representations in formatives and summatives (in formatives they have no “input” level wrapping choices); (2) pools go through the summative-to-formative conversion; but (3) if the pool uses the formative DTD format, as in the L&P cases, this restructures questions into a form whose type is not recognized by subsequent code. Question type detection then falls through cases ending up on short answer type by default.

