### PR TITLE
[BUGFIX] handle implicit input without id [MER-2679]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -487,7 +487,7 @@ function handleInquiry($: any) {
 }
 
 function sideBySideMaterials($: any) {
-  $('materials material').each((i: any, item: any) => {
+  $('materials > material').each((i: any, item: any) => {
     item.tagName = 'td';
   });
   $('materials').each((i: any, item: any) => {

--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -39,11 +39,9 @@ export function determineResourceType(file: string): Promise<ResourceType> {
     if (tag.indexOf('oli_skills_model') !== -1) {
       return 'Skills';
     }
-    if (
-      tag.indexOf('DTD Assessment Pool') !== -1 ||
-      tag.indexOf('pool') !== -1
-    ) {
-      return 'Pool';
+    if (tag.indexOf('pool') !== -1) {
+      // pools may use either summative or formative (inline) assessment DTD
+      return tag.includes('Inline') ? 'FormativePool' : 'Pool';
     }
     if (tag.indexOf('organization') !== -1) {
       return 'Organization';
@@ -106,7 +104,10 @@ export function create(
     return new Superactivity.Superactivity(file, navigable);
   }
   if (t === 'Pool') {
-    return new Pool.Pool(file, navigable);
+    return new Pool.Pool(file, navigable, 'Summative');
+  }
+  if (t === 'FormativePool') {
+    return new Pool.Pool(file, navigable, 'Formative');
   }
   if (t === 'Skills') {
     return new Skills.Skills(file, navigable);

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -590,8 +590,7 @@ export function determineSubType(question: any): ItemTypes {
   if (
     question.originalType !== undefined &&
     Common.getChild(question.children, 'numeric') === undefined &&
-    Common.getChild(question.children, 'text') === undefined &&
-    Common.getChild(question.children, 'fill_in_the_blank') === undefined
+    Common.getChild(question.children, 'text') === undefined
   ) {
     const parts = Common.getChildren(question.children, 'part');
 

--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -7,14 +7,27 @@ import * as XML from 'src/utils/xml';
 import { processCodeblock, processVariables } from './common';
 import { ProjectSummary } from 'src/project';
 
+export type PoolFormat = 'Summative' | 'Formative';
+
 export class Pool extends Resource {
+  poolFormat: PoolFormat = 'Summative';
+
+  constructor(
+    file: string,
+    navigable: boolean,
+    format: PoolFormat = 'Summative'
+  ) {
+    super(file, navigable);
+    this.poolFormat = format;
+  }
+
   restructurePreservingWhitespace($: any): any {
     processCodeblock($);
     processVariables($);
   }
 
   restructure($: any): any {
-    Summative.convertToFormative($);
+    if (this.poolFormat === 'Summative') Summative.convertToFormative($);
     Formative.performRestructure($);
   }
 
@@ -52,6 +65,7 @@ export class Pool extends Resource {
             let poolQuestionNumber = 1;
             item.children.forEach((c: any) => {
               if (c.type !== 'title' && c.type !== 'content') {
+                // console.log('Pool item: ' + JSON.stringify(c, null, 2));
                 const subType = Formative.determineSubType(c);
                 const pooledActivity = Formative.toActivity(
                   c,

--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -65,7 +65,6 @@ export class Pool extends Resource {
             let poolQuestionNumber = 1;
             item.children.forEach((c: any) => {
               if (c.type !== 'title' && c.type !== 'content') {
-                // console.log('Pool item: ' + JSON.stringify(c, null, 2));
                 const subType = Formative.determineSubType(c);
                 const pooledActivity = Formative.toActivity(
                   c,

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -25,7 +25,8 @@ export function buildMulti(
         items[i],
         parts[i],
         i,
-        ignorePartId
+        ignorePartId,
+        question.id
       );
       choices.forEach((c: any) => allChoices.push(c));
       targeted.forEach((c: any) => allTargeted.push(c));
@@ -149,7 +150,8 @@ function produceTorusEquivalents(
   item: any,
   p: any,
   i: number,
-  ignorePartId: boolean
+  ignorePartId: boolean,
+  questionId: string
 ) {
   const input: any = {};
   let part: any = {};
@@ -186,7 +188,7 @@ function produceTorusEquivalents(
   if (item.id) {
     input.id = item.id;
   } else if (item.type === 'text' || item.type === 'numeric') {
-    if (item.children.length === 1) {
+    if (item.children && item.children.length === 1) {
       /*
         Sometimes, we run into a multi-question that the item does not have an id, but there is an
         input ref that points at the choice value.  In this case, we can use the choice value as the
@@ -221,9 +223,10 @@ function produceTorusEquivalents(
       input.id = choice.value;
     }
   }
-
+  // can apparently have minimal question w/implied input but no input id used anywhere
   if (!input.id) {
-    console.warn('No input id found for item: ', item);
+    console.warn(`${questionId} part ${i + 1} ${item.type}: no input id found`);
+    input.id = `${questionId}-${i + 1}`;
   }
 
   input.partId = part.id;

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -19,6 +19,7 @@ export type ResourceType =
   | 'Organization'
   | 'Objectives'
   | 'Pool'
+  | 'FormativePool'
   | 'Formative'
   | 'Summative'
   | 'Discussion'

--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -62,7 +62,9 @@ export function convertToFormative($: any) {
   );
   $('text').each((i: any, item: any) => $(item).attr('originalType', 'text'));
 
-  DOM.rename($, 'multiple_choice', 'question');
+  // AW: this restructuring gets used on pool items which may have multiple_choice in formative
+  // form, w/no input level element, so only rename if has input element now renamed to mc_temp
+  DOM.rename($, 'multiple_choice:has(mc_temp)', 'question');
   DOM.rename($, 'ordering', 'question');
   DOM.rename($, 'short_answer', 'question');
   DOM.rename($, 'fill_in_the_blank', 'question');

--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -52,19 +52,15 @@ export function convertToFormative($: any) {
   DOM.rename($, 'essay input', 'e_temp');
   DOM.rename($, 'image_hotspot input', 'i_temp');
 
-  // For these three types, add an attr to preserve their original types, as there can
-  // be cases where will not have a input level element
-  $('fill_in_the_blank').each((i: any, item: any) =>
-    $(item).attr('originalType', 'fill_in_the_blank')
-  );
+  // For these types, input element is optional. Add attribute recording input type,
+  // so inputs of this type can be synthesized in later processing if needed.
+  // Note fill_in_the_blank must have input to contain choices
   $('numeric').each((i: any, item: any) =>
     $(item).attr('originalType', 'numeric')
   );
   $('text').each((i: any, item: any) => $(item).attr('originalType', 'text'));
 
-  // AW: this restructuring gets used on pool items which may have multiple_choice in formative
-  // form, w/no input level element, so only rename if has input element now renamed to mc_temp
-  DOM.rename($, 'multiple_choice:has(mc_temp)', 'question');
+  DOM.rename($, 'multiple_choice', 'question');
   DOM.rename($, 'ordering', 'question');
   DOM.rename($, 'short_answer', 'question');
   DOM.rename($, 'fill_in_the_blank', 'question');


### PR DESCRIPTION
Legacy apparently allows an input question, say for a numeric input, to be defined minimally with a purely implied input element with no input id mentioned anywhere: no input element, no input_refs in body, and no input id attribute in part responses. Example from STEM Readiness course:
 
```
<numeric id="alg_laws_p6_q1">
        <body> Expand 6.285 &#8226; 10<sup>3</sup>
        </body>
        <part>
            <response match="6285" score="10">
                <feedback>Correct. You moved the decimal point three places to the right.</feedback>
            </response>
            <response match="*" score="0">
                <feedback>Incorrect. Move the decimal point three places to the right.</feedback>
            </response>
        </part>
  </numeric>
```

Migration tool does synthesize implied input elements, but wound up crashing if id not referenced in part response elements. This change detects that case and generates an id for it.