### PR TITLE
[ENHANCEMENT] convert multipart mcq to multi-input w/dropdowns [MER-2693]

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -555,6 +555,16 @@ export function determineSubType(question: any): ItemTypes {
     if (mcq.select && mcq.select === 'multiple') {
       return 'oli_check_all_that_apply';
     }
+    if (Common.getChildren(question.children, 'part').length > 1) {
+      console.warn(
+        question.id +
+          ' Multi-part multiple choice unsupported; converting to dropdown choices '
+      );
+      Common.getChildren(question.children, 'multiple_choice').forEach(
+        (input: any) => (input.type = 'fill_in_the_blank')
+      );
+      return 'oli_multi_input';
+    }
     return 'oli_multiple_choice';
   }
 


### PR DESCRIPTION
Legacy OLI allowed multi-part multiple choice questions, unsupported in Torus. Digest tool was converting only the first part. This change converts multipart mcqs to the nearest equivalent in torus, multi-input questions with dropdown parts. This may not be an acceptable presentation of choice content; prints a warning on each instance so these can be identified for careful review. 