### PR TITLE
 [BUGFIX] fix lost popup content [MER-2696]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -105,10 +105,6 @@ export function failIfHasValue(
 }
 
 export function standardContentManipulations($: any) {
-  $('extra').each((i: any, elem: any) => {
-    console.log('extra: ' + $(elem).html());
-  });
-
   failIfPresent($, ['ipa', 'bdo']);
 
   handleCommandButtons($);

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -105,6 +105,10 @@ export function failIfHasValue(
 }
 
 export function standardContentManipulations($: any) {
+  $('extra').each((i: any, elem: any) => {
+    console.log('extra: ' + $(elem).html());
+  });
+
   failIfPresent($, ['ipa', 'bdo']);
 
   handleCommandButtons($);
@@ -227,28 +231,29 @@ export function standardContentManipulations($: any) {
   stripNonDefaultMediaSizing($, 'iframe');
   stripMediaSizing($, 'youtube');
 
-  DOM.stripElement($, 'p ol');
-  DOM.stripElement($, 'p ul');
-  DOM.stripElement($, 'p li');
-  DOM.stripElement($, 'p ol');
-  DOM.stripElement($, 'p ul');
-  DOM.stripElement($, 'p li');
-  DOM.stripElement($, 'p ol');
-  DOM.stripElement($, 'p ul');
-  DOM.stripElement($, 'p li');
-  DOM.stripElement($, 'p p');
-  DOM.stripElement($, 'p p');
+  DOM.stripElement($, 'p>ol');
+  DOM.stripElement($, 'p>ul');
+  DOM.stripElement($, 'p>li');
+  DOM.stripElement($, 'p>ol');
+  DOM.stripElement($, 'p>ul');
+  DOM.stripElement($, 'p>li');
+  DOM.stripElement($, 'p>ol');
+  DOM.stripElement($, 'p>ul');
+  DOM.stripElement($, 'p>li');
+
+  DOM.stripElement($, 'p>p');
+  DOM.stripElement($, 'p>p');
 
   // Change to allow block elements within list items
   // DOM.stripElement($, 'li p');
   // DOM.rename($, 'li img', 'img_inline');
 
-  DOM.stripElement($, 'p quote');
+  DOM.stripElement($, 'p>quote');
 
-  $('p table').remove();
-  $('p title').remove();
-  $('ol title').remove();
-  $('ul title').remove();
+  $('p>table').remove();
+  $('p>title').remove();
+  $('ol>title').remove();
+  $('ul>title').remove();
 
   DOM.rename($, 'quote', 'blockquote');
   DOM.rename($, 'composite_activity title', 'p');

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -262,10 +262,18 @@ export function toJSON(
 
       const elevatePopoverContent = () => {
         if (tag === 'popup') {
+          console.log('popup: ' + JSON.stringify(top(), null, 2));
           const anchor = getOneOfType(top().children, 'anchor');
           const meaning = getOneOfType(top().children, 'meaning');
           const pronunciation = getOneOfType(top().children, 'pronunciation');
           const translation = getOneOfType(top().children, 'translation');
+          // element may content popup content w/no semantic subelement wrapper used
+          const elementContent = top().children.filter(
+            (e: any) =>
+              !['anchor', 'meaning', 'translation', 'pronunciation'].includes(
+                e.type
+              )
+          );
 
           if (anchor !== null) {
             top().children = anchor.children;
@@ -281,6 +289,8 @@ export function toJSON(
               top().content = material.children;
             } else if (translation !== null) {
               top().content = translation.children;
+            } else if (elementContent.length > 0) {
+              top().content = elementContent;
             } else {
               top().content = [{ type: 'text', text: ' ' }];
             }

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -262,7 +262,6 @@ export function toJSON(
 
       const elevatePopoverContent = () => {
         if (tag === 'popup') {
-          console.log('popup: ' + JSON.stringify(top(), null, 2));
           const anchor = getOneOfType(top().children, 'anchor');
           const meaning = getOneOfType(top().children, 'meaning');
           const pronunciation = getOneOfType(top().children, 'pronunciation');

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -266,7 +266,7 @@ export function toJSON(
           const meaning = getOneOfType(top().children, 'meaning');
           const pronunciation = getOneOfType(top().children, 'pronunciation');
           const translation = getOneOfType(top().children, 'translation');
-          // element may content popup content w/no semantic subelement wrapper used
+          // element may contain popup content w/no semantic subelement wrapper used
           const elementContent = top().children.filter(
             (e: any) =>
               !['anchor', 'meaning', 'translation', 'pronunciation'].includes(


### PR DESCRIPTION
This fixes two issues involved with missing popup (legacy `<extra>`) content. First, popup content may be specified in the `<extra>` element content without being wrapped in a semantic subelement like meaning or translation. This case was not being handled.

Second, standard content manipulations to strip bad nested HTML, for example to strip an unordered list within a paragraph, were using selectors that reached down into all descendants. So if a paragraph contained text with an extra (popup) that contained structured content like an unordered list, the nested list level would be stripped because it is contained within a paragraph, leading to incorrect content in the popups. This change revises the selectors to reach only immediate children.