### PR TITLE
[BUGFIX] Fix handling of term element within definition content [MER-2706]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -114,7 +114,7 @@ export function standardContentManipulations($: any) {
   DOM.unwrapInlinedMedia($, 'youtube');
   DOM.unwrapInlinedMedia($, 'iframe');
 
-  DOM.rename($, 'definition term', 'definition-term');
+  DOM.rename($, 'definition>term', 'definition-term');
 
   // Change sub within sub to distinct doublesub mark. Will remove the
   // regular sub style from doublesub text when collecting styles in toJSON
@@ -473,6 +473,8 @@ function handleDefinitions($: any) {
     const term = $(elem).children('definition-term').text();
     $(elem).children().remove('definition-term');
     $(elem).attr('term', term);
+    console.log('Definition out :');
+    console.log($.html(elem));
   });
 }
 

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -473,8 +473,6 @@ function handleDefinitions($: any) {
     const term = $(elem).children('definition-term').text();
     $(elem).children().remove('definition-term');
     $(elem).attr('term', term);
-    console.log('Definition out :');
-    console.log($.html(elem));
   });
 }
 


### PR DESCRIPTION
If a `term` is contained within the content of a `definition` (to highlight some term within that content), it gets migrated into a definition-term, a temporary tool-internal translation which is never eliminated in this case. This causes an “unsupported content element: definition-term” error after ingestion.

This happens because the restructuring code uses a selector "definition term" which reaches into arbitrarily nested descendants, so hits term elements within defnition content when it should not. Fix is to use a selector "`definition>term`" which finds only immediate children. 