### PR TITLE
[BUGFIX] Migrate list titles [MER-2714]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -248,8 +248,9 @@ export function standardContentManipulations($: any) {
 
   $('p>table').remove();
   $('p>title').remove();
-  $('ol>title').remove();
-  $('ul>title').remove();
+  // handle titles of lists
+  DOM.handleLabelledContent($, 'ol');
+  DOM.handleLabelledContent($, 'ul');
 
   DOM.rename($, 'quote', 'blockquote');
   DOM.rename($, 'composite_activity title', 'p');

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -114,7 +114,7 @@ export function standardContentManipulations($: any) {
   DOM.unwrapInlinedMedia($, 'youtube');
   DOM.unwrapInlinedMedia($, 'iframe');
 
-  DOM.rename($, 'definition term', 'definition-term');
+  DOM.rename($, 'definition>term', 'definition-term');
 
   // Change sub within sub to distinct doublesub mark. Will remove the
   // regular sub style from doublesub text when collecting styles in toJSON
@@ -473,6 +473,8 @@ function handleDefinitions($: any) {
     const term = $(elem).children('definition-term').text();
     $(elem).children().remove('definition-term');
     $(elem).attr('term', term);
+    console.log('Definition out :');
+    console.log($.html(elem));
   });
 }
 

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -473,8 +473,6 @@ function handleDefinitions($: any) {
     const term = $(elem).children('definition-term').text();
     $(elem).children().remove('definition-term');
     $(elem).attr('term', term);
-    console.log('Definition out :');
-    console.log($.html(elem));
   });
 }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -217,7 +217,7 @@ function mergeElement($: any, selector: string, element: string) {
   });
 }
 
-function handleLabelledContent($: any, selector: string) {
+export function handleLabelledContent($: any, selector: string) {
   const items = $(selector);
 
   items.each((i: any, elem: any) => {


### PR DESCRIPTION
Legacy OLI permitted lists (ol and ul) to have a title element. Migration tool was not passing these through. This PR turns them into h5 headers prepended to the list, via same routine that processes media titltes. 