### PR TITLE
[ENHANCEMENT] include preference conditional content [MER-2715]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -310,6 +310,9 @@ export function standardContentManipulations($: any) {
   handleConjugations($);
   handleAlternatives($);
 
+  // preference-conditional inclusion not supported. Include to avoid error; let reviewers handle
+  DOM.stripElement($, 'pref\\:if');
+
   DOM.rename($, 'li formula', 'formula_inline');
   DOM.rename($, 'li callback', 'callback_inline');
 }


### PR DESCRIPTION
Legacy OLI allowed for conditional inclusion of content based on instructors choice of a course-defined preference setting via the `pref:if` tag. Use of this gives rise to unsupported content error in migrated content. Since there is no corresponding feature in torus, this change always includes the content to avoid error and allow reviewing instructors to decide how to handle it in torus. 