### PR TITLE
[BUGFIX] Migrate pullouts  to blockquotes [MER-2733]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -271,7 +271,7 @@ export function standardContentManipulations($: any) {
     $(item).prepend(`<em>${typeHeader}...</em>`);
   });
   DOM.rename($, 'pullout title', 'p');
-  DOM.rename($, 'pullout', 'group');
+  DOM.rename($, 'pullout', 'blockquote');
 
   $('example').each((i: any, item: any) => {
     $(item).attr('purpose', 'example');


### PR DESCRIPTION
Legacy uses pullouts for content that should be set off from the main flow in some way. Migration was turning these into ordinary paragraphs, losing any indication that they are set off. This change maps pullouts to blockquotes since blockquotes are set off in close to the desired way.

It would seem to be a more natural alternative to migrate to torus callouts. However torus callouts center each line, apparently for the purpose of display formulas written using ordinary text rather than formulas. This is an odd style for pullout content. So, using blockquote as the closest approximation among existing torus content elements. 