### PR TITLE
[BUGFIX] strip video size parameters for centered layout [MER-2727]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -227,6 +227,9 @@ export function standardContentManipulations($: any) {
   stripNonDefaultMediaSizing($, 'iframe');
   stripMediaSizing($, 'youtube');
 
+  // videos with size parameters have layout issue (not centered), so strip
+  stripMediaSizing($, 'video');
+
   DOM.stripElement($, 'p>ol');
   DOM.stripElement($, 'p>ul');
   DOM.stripElement($, 'p>li');


### PR DESCRIPTION
Videos with height and width parameters are not being centered in torus. This affected all videos in Logic and Proofs course, which always included intrinsic resolution of video as parameters which ensured display without scaling. This change has the migration tool strip video size parameters to prevent this issue.  Videos will display at a default size, which may then. be scaled from the original resolution. 