### PR TITLE
[BUGFIX] map term inline style to torus term, not strong [MER-2734]

### DIFF
--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -64,6 +64,8 @@ function inlineAttrName(attrs: Record<string, unknown>) {
     return 'doublesub';
   } else if (attrs['style'] === 'deemphasis') {
     return 'deemphasis';
+  } else if (attrs['style'] === 'term') {
+    return 'term';
   } else {
     return 'strong';
   }


### PR DESCRIPTION
Term style was being detected, but missing clause meant it was mapped to strong. Can be mapped to torus term so these show up in green, the style for terms as in legacy.