### PR TITLE
[BUGFIX] check image style before inferring block or inline [MER-2736]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -166,7 +166,11 @@ export function standardContentManipulations($: any) {
   DOM.rename($, 'a img', 'img_inline');
 
   $('img').each((i: any, item: any) => {
-    if (DOM.isInlineElement($, item)) {
+    const style = $(item).attr('style');
+    if (
+      style === 'inline' ||
+      (DOM.isInlineElement($, item) && style !== 'block')
+    ) {
       item.tagName = 'img_inline';
     }
   });


### PR DESCRIPTION
Digest tool was not checking image style attribute (block or inline) before applying its method for inferring whether image should be block or inline. This wound up converting an image explicitly styled as inline into a block image. Change is to give explicit block vs image style priority in deciding.