### PR TITLE
[BUGFIX] migrate highlight style to mark [MER-2737]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -132,12 +132,16 @@ export function standardContentManipulations($: any) {
   $('deemphasis').each((i: any, item: any) =>
     $(item).attr('style', 'deemphasis')
   );
+  $('highlight').each((i: any, item: any) =>
+    $(item).attr('style', 'highlight')
+  );
   DOM.rename($, 'var', 'em');
   DOM.rename($, 'term', 'em');
   DOM.rename($, 'sub', 'em');
   DOM.rename($, 'sup', 'em');
   DOM.rename($, 'doublesub', 'em');
   DOM.rename($, 'deemphasis', 'em');
+  DOM.rename($, 'highlight', 'em');
 
   // <code> is a mixed element, we only want to translate the inline <code>
   // instances to <em> elements.  The block level <code> will get converted

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -56,6 +56,8 @@ function inlineAttrName(attrs: Record<string, unknown>) {
   }
   if (attrs['style'] === 'code') {
     return 'code';
+  } else if (attrs['style'] === 'highlight') {
+    return 'mark';
   } else if (attrs['style'] === 'sub') {
     return 'sub';
   } else if (attrs['style'] === 'sup') {


### PR DESCRIPTION
Legacy highlight style was not being processed. This migrates to torus 'mark' style, which renders as highlight. Note highlight style not yet offered on text styling menu in torus authoring, but apparently implemented.