### PR TITLE
[ENHANCEMENT] set legacyBlockRendered flag on inline MathML w/display="block" [MER-2740]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -595,8 +595,18 @@ export function handleTheorems($: any) {
 }
 
 export function handleFormulaMathML($: any) {
+  // Flag MathML formulas w/display=block as block rendered even if inline
+  $('formula:has(m\\:math[display="block"])').each((i: any, item: any) => {
+    $(item).attr('legacyBlockRendered', true);
+  });
+  $('formula:has(math[display="block"])').each((i: any, item: any) => {
+    $(item).attr('legacyBlockRendered', true);
+  });
+
   $('formula').each((i: any, item: any) => {
     const subtype = determineFormulaType(item);
+    const tag = item.tagName;
+
     if (subtype === 'mathml') {
       $(item).attr('src', getFirstMathML($, item));
       item.children = [];
@@ -613,8 +623,8 @@ export function handleFormulaMathML($: any) {
   });
 
   // For formula inside of paragraphs, we know they are of the inline variety
-  DOM.rename($, 'p formula', 'formula_inline');
-  DOM.rename($, 'p callout', 'callout_inline');
+  DOM.rename($, 'p > formula', 'formula_inline');
+  DOM.rename($, 'p > callout', 'callout_inline');
 
   // All others, we must inspect their context to determine whether they are
   // inline or block
@@ -623,6 +633,7 @@ export function handleFormulaMathML($: any) {
       item.tagName = 'formula_inline';
     }
   });
+
   $('callout').each((i: any, item: any) => {
     if (DOM.isInlineElement($, item)) {
       item.tagName = 'callout_inline';


### PR DESCRIPTION
MathML including display="block" is intended to render as block even if embedded inline in paragraph text, and did so in legacy. Torus has supported the legacyBlockRendered flag for this case with LaTex formulas. This change sets the flag to handle this case for MathML as well. 

Requires torus change to process this flag on MathML formulas as it does for LaTex, for which there is a related torus PR.