### PR TITLE
[BUGFIX] handle untitled figures [MER-2751]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -116,6 +116,12 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'definition>term', 'definition-term');
 
+  // Torus figures require a title element. Do this
+  // early in case any further title processing below
+  $('figure:not(:has(title))').each((i: any, elem: any) => {
+    $(elem).prepend('<title></title>');
+  });
+
   // Change sub within sub to distinct doublesub mark. Will remove the
   // regular sub style from doublesub text when collecting styles in toJSON
   DOM.rename($, 'sub sub', 'doublesub');

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -595,8 +595,18 @@ export function handleTheorems($: any) {
 }
 
 export function handleFormulaMathML($: any) {
+  // Flag MathML formulas w/display=block as block rendered even if inline
+  $('formula:has(m\\:math[display="block"])').each((i: any, item: any) => {
+    $(item).attr('legacyBlockRendered', true);
+  });
+  $('formula:has(math[display="block"])').each((i: any, item: any) => {
+    $(item).attr('legacyBlockRendered', true);
+  });
+
   $('formula').each((i: any, item: any) => {
     const subtype = determineFormulaType(item);
+    const tag = item.tagName;
+
     if (subtype === 'mathml') {
       $(item).attr('src', getFirstMathML($, item));
       item.children = [];
@@ -613,8 +623,8 @@ export function handleFormulaMathML($: any) {
   });
 
   // For formula inside of paragraphs, we know they are of the inline variety
-  DOM.rename($, 'p formula', 'formula_inline');
-  DOM.rename($, 'p callout', 'callout_inline');
+  DOM.rename($, 'p > formula', 'formula_inline');
+  DOM.rename($, 'p > callout', 'callout_inline');
 
   // All others, we must inspect their context to determine whether they are
   // inline or block
@@ -623,6 +633,7 @@ export function handleFormulaMathML($: any) {
       item.tagName = 'formula_inline';
     }
   });
+
   $('callout').each((i: any, item: any) => {
     if (DOM.isInlineElement($, item)) {
       item.tagName = 'callout_inline';

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -605,7 +605,6 @@ export function handleFormulaMathML($: any) {
 
   $('formula').each((i: any, item: any) => {
     const subtype = determineFormulaType(item);
-    const tag = item.tagName;
 
     if (subtype === 'mathml') {
       $(item).attr('src', getFirstMathML($, item));

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -116,8 +116,8 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'definition>term', 'definition-term');
 
-  // Torus figures require a title element. Do this
-  // early in case any further title processing below
+  // Torus figures require a title, so add one if missing. Do this
+  // early to ensure gets any further title processing below
   $('figure:not(:has(title))').each((i: any, elem: any) => {
     $(elem).prepend('<title></title>');
   });

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -232,6 +232,7 @@ export function handleLabelledContent($: any, selector: string) {
 
 export function removeSelfClosing($: any) {
   $('caption').removeAttr('___selfClosing___');
+  $('title').removeAttr('___selfClosing___');
   $('image').removeAttr('___selfClosing___');
   $('th').removeAttr('___selfClosing___');
   $('td').removeAttr('___selfClosing___');

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -310,6 +310,15 @@ export function toJSON(
         }
       };
 
+      const elevateTitle = (parent: string) => {
+        if (tag === 'title' && stack[stack.length - 2].type === parent) {
+          if (stack.length > 1) {
+            stack[stack.length - 2].title = top().children;
+            stack[stack.length - 2].children = [{ type: 'text', text: ' ' }];
+          }
+        }
+      };
+
       const elevateTableCaption = () => {
         if (tag === 'caption' && stack[stack.length - 2].type === 'table') {
           if (stack.length > 1) {
@@ -572,6 +581,7 @@ export function toJSON(
         elevateCaption('youtube');
         elevateTableCaption();
         elevateCaption('audio');
+        elevateTitle('figure');
         elevatePopoverContent();
         unescapeFormulaSrc();
         unescapeVariableData();


### PR DESCRIPTION
Torus requires a title attribute on a Figure element. Legacy figures did not need to include a title, giving rise to a rendering failure on migrated untitled figures with message "unsupported content element: figure". This change has migration tool  insert an empty title in this case.  Also adds the step of "elevating" content in a figure's child title element in the original XML to a title _attribute_ in the json figure object, which it appears was not being done.

Closes oli-torus:#4405