### PR TITLE
[ENHANCEMENT] never inline captioned images [MER-2769]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -172,8 +172,10 @@ export function standardContentManipulations($: any) {
   $('img').each((i: any, item: any) => {
     const style = $(item).attr('style');
     if (
-      style === 'inline' ||
-      (DOM.isInlineElement($, item) && style !== 'block')
+      // don't inline if captioned no matter what style specified
+      isUnCaptioned($, item) &&
+      (style === 'inline' ||
+        (DOM.isInlineElement($, item) && style !== 'block'))
     ) {
       item.tagName = 'img_inline';
     }
@@ -371,6 +373,14 @@ function stripEmptyCaptions($: any, selector: string) {
       }
     }
   });
+}
+
+function isUnCaptioned($: any, item: any) {
+  const caption = $(item).find('caption');
+  return (
+    caption === undefined ||
+    (caption.text().trim() === '' && caption.children().length === 0)
+  );
 }
 
 // Strip any sizing that's not the default 800x450 that iframes use


### PR DESCRIPTION
Had example of an image with style=”inline” and a caption. This appeared centered because it was contained within an untitled figure element. This included caption in legacy, but inline images do not show captions in torus.

While this might be addressed by changing source styling to block, this change has migration tool treat all images with captions as block images regardless of style specified, so that the caption will be preserved.