### PR TITLE
[BUGFIX] preserve non-breaking spaces in mathML formula [MER-2780]

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -47,7 +47,7 @@ export function guid() {
 export function decodeEntities(encodedString: string) {
   const translate_re = /&(nbsp|amp|quot|lt|gt);/g;
   const translate = {
-    nbsp: ' ',
+    nbsp: '\xA0', // unicode nbsp 160
     amp: '&',
     quot: '"',
     lt: '<',


### PR DESCRIPTION
Non-breaking spaces in MathML formula were not being preserved -- they were converting to regular spaces which could be normalized away in course of parsing, defeating the attempt to achieve particular spacing with them. This changes the decodeEntities function which is applied to formula content to map the` nbsp;` entity to a unicode non-breaking space character.