### PR TITLE
[ENHANCEMENT] convert line-through inline style to strikethrough [MER-2781]

### DIFF
--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -68,7 +68,10 @@ function inlineAttrName(attrs: Record<string, unknown>) {
     return 'deemphasis';
   } else if (attrs['style'] === 'term') {
     return 'term';
+  } else if (attrs['style'] === 'line-through') {
+    return 'strikethrough';
   } else {
+    if (attrs['style']) console.log('unknown inline style: ' + attrs['style']);
     return 'strong';
   }
 }


### PR DESCRIPTION
Legacy OLI allowed  `<em style="line-through">` to get strikethrough formatting. This change migrates this to torus strikethrough.

Used in Logic and Proofs, which used a series of non-breaking space characters with line-through styling to get a horizontal line used to separate premises from conclusion in a presentation of an argument. This change is necessary but not sufficient for that to migrate, as there is still a problem passing non-breaking space entities through the migration tool.