### PR TITLE
[BUGFIX] include uncited references in page reference list [MER-2771]

### DIFF
--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -180,6 +180,7 @@ export class WorkbookPage extends Resource {
     xml = convertBibliographyEntries($, bibEntries);
 
     const bibrefs: number[] = [];
+
     $('cite').each((i: any, elem: any) => {
       const entry = $(elem).attr('entry');
       const bibRef = bibEntries.get(entry);
@@ -193,6 +194,11 @@ export class WorkbookPage extends Resource {
       } else {
         $(elem).remove();
       }
+    });
+    // Also include any uncited refs. Handles case we've seen of references
+    // listed but only cited in text as Smith (1984) w/o citation links
+    bibEntries.forEach((bibEntry) => {
+      if (!bibrefs.includes(bibEntry.id)) bibrefs.push(bibEntry.id);
     });
 
     const objectives: TorusResource[] = [];


### PR DESCRIPTION
Digest tool was only including references in page reference list for which there were citations somewhere on the page. But some courses (Systematic Reviews) only cite references in the text in the `Littel (1984)` style without using citation entities. These still want page's references listed (as was done in legacy), so this PR adds uncited references to the page's reference list, which handles this case, as well as the case of a mix of cited and uncited references.

Note it continues to add cited references to the list first since references appear in the order listed, so this makes cited references come out first in order of citation. 