### PR TITLE
[ENHANCEMENT] Give element titles distinctive style [MER-2798]

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -225,7 +225,7 @@ export function handleLabelledContent($: any, selector: string) {
     $(elem).children().remove('title');
 
     if (title) {
-      $('<h5>' + title + '</h5>').insertBefore($(elem));
+      $('<h6><em>' + title + '</em></h6>').insertBefore($(elem));
     }
   });
 }

--- a/test/utils/dom-test.ts
+++ b/test/utils/dom-test.ts
@@ -129,7 +129,7 @@ describe('dom mutations', () => {
 
   test('should mergeCaptions with title', () => {
     const content =
-      '<a><youtube id="d74862fd549747f6b7bf366768378591" src="9ixG0YbDSSw?showinfo=0;" height="500" width="1000" controls="true"><title><p>A Wonderful Title</p></title></youtube></a>';
+      '<a><youtube id="d74862fd549747f6b7bf366768378591" src="9ixG0YbDSSw?showinfo=0;" height="500" width="1000" controls="true"><title>A Wonderful Title</title></youtube></a>';
 
     const $ = cheerio.load(content, {
       normalizeWhitespace: true,
@@ -138,7 +138,7 @@ describe('dom mutations', () => {
 
     mergeCaptions($);
 
-    expect($.xml()).toContain('<h5><p>A Wonderful Title</p></h5>');
+    expect($.xml()).toContain('<h6><em>A Wonderful Title</em></h6>');
   });
 
   test('should mergeCaptions without title', () => {


### PR DESCRIPTION
In addition to captions, legacy OLI allowed titles to be associated with tables/images/iframes/audio/video clips. Torus does not have title elements associated with these. Migration was mapping them to h5 headers, which are not supported as a distinctive element in torus so render in the same way as ordinary text. This PR sets titles on labelled content to display in bold so that they are distinguished from regular text (as in legacy). 

Also changes to use h6 per group discussion so they are distinctive elements unlikely to conflict with section headers even in the future. 