### PR TITLE
[ENHANCEMENT] convert response mult [MER-2858]

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -20,7 +20,7 @@ import {
   process as processCustomDnd,
 } from './questions/custom-dnd';
 import { cata } from './questions/cata';
-import { buildMulti } from './questions/multi';
+import { buildMulti, buildResponseMulti } from './questions/multi';
 import * as DOM from 'src/utils/dom';
 import * as XML from 'src/utils/xml';
 import * as Common from './questions/common';
@@ -414,6 +414,9 @@ function buildModel(subType: ItemTypes, question: any, baseFileName: string) {
   if (subType === 'oli_multi_input') {
     return [buildMulti(question), []];
   }
+  if (subType === 'oli_response_multi') {
+    return [buildResponseMulti(question), []];
+  }
   if (subType === 'oli_custom_dnd') {
     const multipart = buildMulti(question, true, true);
     return processCustomDnd(multipart, baseFileName);
@@ -452,10 +455,6 @@ export function toActivity(
   activity.id = legacyId + '-' + question.id;
   // provisional title, may be adjusted by caller w/more context
   activity.title = activity.id;
-
-  const result = Common.getDescendants(question.children, 'response_mult');
-  if (result.length > 0)
-    console.log(question.id + ' unsupported element: response_mult ');
 
   const [content, imageReferences] = buildModel(
     subType,
@@ -545,6 +544,7 @@ type ItemTypes =
   | 'oli_short_answer'
   | 'oli_ordering'
   | 'oli_multi_input'
+  | 'oli_response_multi'
   | 'oli_likert'
   | 'oli_image_hotspot';
 
@@ -583,7 +583,8 @@ export function determineSubType(question: any): ItemTypes {
       return 'oli_custom_dnd';
     }
 
-    return 'oli_multi_input';
+    const mults = Common.getDescendants(question.children, 'response_mult');
+    return mults.length > 0 ? 'oli_response_multi' : 'oli_multi_input';
   }
 
   const likert_scale = Common.getChild(question.children, 'likert_scale');

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -259,7 +259,11 @@ const getParts = (question: any): any[] =>
   question.children.filter((c: any) => c.type === 'part');
 
 export function getFeedbackModel(response: any) {
-  if (response.children === undefined || response.children.length === 0) {
+  const feedback =
+    response.children !== undefined
+      ? getChild(response.children, 'feedback')
+      : undefined;
+  if (feedback === undefined) {
     return [
       {
         type: 'p',
@@ -267,7 +271,8 @@ export function getFeedbackModel(response: any) {
       },
     ];
   }
-  return ensureParagraphs(response.children[0].children);
+
+  return ensureParagraphs(feedback.children);
 }
 
 const getResponseFeedbacks = (r: any) =>

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -259,10 +259,16 @@ const getParts = (question: any): any[] =>
   question.children.filter((c: any) => c.type === 'part');
 
 export function getFeedbackModel(response: any) {
-  const feedback =
+  let feedback =
     response.children !== undefined
       ? getChild(response.children, 'feedback')
       : undefined;
+
+  // odd case seen on responses generated for mcq's on surveys: feedback
+  // content is direct child of response, not wrapped in <feedback> element
+  if (feedback === undefined && response.children.length > 0)
+    feedback = response.children[0];
+
   if (feedback === undefined) {
     return [
       {

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -1,6 +1,7 @@
 import { guid } from 'src/utils/common';
 import * as Common from './common';
 import { convertCatchAll } from './common';
+import { andRules, orRules } from './rules';
 
 // Assemble the Torus representation of a multi-input activity from
 // a JSON representation of the Formative Legacy model of this question type
@@ -608,7 +609,10 @@ const compoundRule = (match_style: string, matches: any, items: any[]) => {
       : inputRules;
 
   // combine the base rules into compound torus rule
-  const joined = cleanedRules.join(match_style === 'all' ? ' && ' : ' || ');
+  const joined =
+    match_style === 'all'
+      ? andRules(...cleanedRules)
+      : orRules(...cleanedRules);
   return match_style === 'none' ? `!(${joined})` : joined;
 };
 

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -603,7 +603,8 @@ const compoundRule = (match_style: string, matches: any, items: any[]) => {
   // Assumes no conflicting rules for same input like (input1=A || input1=*)
   // !!! Not equivalent if wildcard match requires SOME input while input may be left unfilled.
   // Have seen 3-item questions where input3 is optional: correct response leaves out input3 ,
-  // and wildcard match on 3 used to detect error of including any response to 3.
+  // and wildcard match on 3 used to detect error of including any response to 3. But torus
+  // does not support this use of wildcards, so such questions will have to change in any case.
   const nonCatchAllRules = inputRules.filter((r: string) => !r.includes('.*'));
   const cleanedRules =
     nonCatchAllRules.length > 0 && match_style != 'none'

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -1,4 +1,4 @@
-import { guid, replaceAll } from 'src/utils/common';
+import { guid } from 'src/utils/common';
 import * as Common from './common';
 import { convertCatchAll } from './common';
 
@@ -451,9 +451,7 @@ export function buildResponseMulti(question: any) {
   const stem = buildStem(question, inputs, true);
 
   // walk the parts, building torus parts with multi response rules
-  const torusParts = parts.map((p: any) =>
-    toResponseMultiPart(p, items, choices)
-  );
+  const torusParts = parts.map((p: any) => toResponseMultiPart(p, items));
 
   // set transformations particularly shuffle
   const transformationElement = Common.getChild(
@@ -517,7 +515,7 @@ const toResponseMultiInput = (item: any, parts: any[]) => {
 };
 
 // create torus part from a legacy response_mult part
-const toResponseMultiPart = (part: any, items: any[], choices: any[]) => {
+const toResponseMultiPart = (part: any, items: any[]) => {
   // A single-input part may have regular responses, not response_mults
   const responses = [
     ...Common.getChildren(part.children, 'response_mult'),
@@ -529,9 +527,7 @@ const toResponseMultiPart = (part: any, items: any[], choices: any[]) => {
   return {
     id: part.id,
     targets: part.targets.split(','),
-    responses: responses.map((r: any) =>
-      toResponseMultiResponse(r, items, choices)
-    ),
+    responses: responses.map((r: any) => toResponseMultiResponse(r, items)),
     hints: Common.ensureThree(
       hints.map((r: any) => ({
         id: guid(),
@@ -551,7 +547,7 @@ const toResponseMultiPart = (part: any, items: any[], choices: any[]) => {
 // But for a single-input part we may get regular response element
 //    <response match=".." input="...>
 // We build a response mult style rule even for single response
-const toResponseMultiResponse = (r: any, items: any[], choices: any[]) => {
+const toResponseMultiResponse = (r: any, items: any[]) => {
   const matches =
     r.type === 'response_mult' ? Common.getChildren(r.children, 'match') : [r];
   const matchStyle = r.type === 'response_mult' ? r.match_style : 'all';


### PR DESCRIPTION
This adds support for translating legacy questions using response_mult into new torus response_multi activities. Legacy response_mult allowed for grouping *sets* of inputs in a multi-input style question and treating those sets as a single part, via response rules that match responses over the set of "target" inputs in that part. 