### PR TITLE
[ENHANCEMENT] remove block code wrapping  mathml formula [MER-2982]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -157,6 +157,9 @@ export function standardContentManipulations($: any) {
     DOM.rename($, `${e} code`, 'em');
   });
 
+  // One course wrapped mathML in code for style; won't work in torus block code box
+  DOM.rename($, 'code:has(m\\:math)', 'p');
+
   // Certain constructs have to be converted into an alternate
   // representation for how Torus supports them
   DOM.flattenNestedSections($);


### PR DESCRIPTION
Logic and Proofs courses wrapped many formulas in `<code>` elements for stylistic purposes. While OK if inline, when it results in a block code box, the result in torus doesn't handle this. This PR replaces block code around mathml with p tags.