### PR TITLE
 [BUGFIX] dont include correct answer in mcq targeted feedback [MER-3033]

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -107,7 +107,9 @@ function buildMCQPart(question: any) {
   }
 
   const targeted: any = [];
-  const correctId = r.find((r: any) => r.score > 0)?.id;
+  const correctId = r.find(
+    (r: any) => r.score !== undefined && r.score > 0
+  )?.id;
   r.forEach((r: any) => {
     if (r.legacyMatch !== '.*' && r.id !== correctId) {
       targeted.push([[r.legacyMatch], r.id]);

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -107,9 +107,9 @@ function buildMCQPart(question: any) {
   }
 
   const targeted: any = [];
-
+  const correctId = r.find((r: any) => r.score > 0)?.id;
   r.forEach((r: any) => {
-    if (r.legacyMatch !== '.*') {
+    if (r.legacyMatch !== '.*' && r.id !== correctId) {
       targeted.push([[r.legacyMatch], r.id]);
     }
   });


### PR DESCRIPTION
Migration tool had been including the correct answer in the targeted feedback list attached to multiple choice questions. While this does not prevent the question from working correctly, it allows the correct answer to be deleted in torus authoring by deleting that targeted feedback, which puts the question in an error state preventing further editing. This corrects migration tool to exclude correct answer from the targeted feedback list.  