### PR TITLE
[BUGFIX] ensure multi-input feedback in order of associated inputs [MER-3039]

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -426,8 +426,8 @@ function createContentWithLink(title: string, idref: string) {
   return content;
 }
 
-/* 
-Check activity for input order mismatches and log w/page or pool title
+/*
+// Check activity for input order mismatch. Log w/page title so authors can easily find
 export const checkActivity = (activity: Activity, page: string) => {
   if (activity.subType === 'oli_multi_input') {
     const q: any = activity.content;

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -54,6 +54,23 @@ export function buildMulti(
 
   const stem = buildStem(question, inputs, skipInputRefValidation);
 
+  // list parts in order of input refs in stem (affects order of feedbacks)
+  const iRefToPart = (iRef: any) => {
+    const part = torusParts.find(
+      (p) => p.id === inputs.find((input: any) => input.id === iRef.id)?.partId
+    );
+    if (part === undefined)
+      console.log(
+        `${question.id}: part not found via inputs for input_ref ${iRef.id}`
+      );
+    return part;
+  };
+  const orderedParts = skipInputRefValidation
+    ? torusParts
+    : Common.getDescendants(stem.content, 'input_ref')
+        .map(iRefToPart)
+        .filter((p) => p !== undefined);
+
   return {
     stem,
     choices: allChoices,
@@ -61,7 +78,7 @@ export function buildMulti(
     submitPerPart: true,
     authoring: {
       targeted: allTargeted,
-      parts: torusParts,
+      parts: orderedParts,
       transformations: transformations,
       previewText: '',
     },


### PR DESCRIPTION
Multi-input feedbacks in torus are presented in a list in the order of the parts in the part list. But in some cases, legacy source XML will result in parts for migrated courses coming out in different order than order of inputs in the question stem (it will be order of input section list, to be precise, which may be arbitrary), causing confusion for students matching up feedbacks to inputs. This has migration tool sort parts to ensure parts are listed in order of input items in the question stem.