### PR TITLE
[ENHANCEMENT] trim whitespace from text answer match strings [MER-3041]

### DIFF
--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -331,7 +331,7 @@ export function buildTextPart(id: string, question: any) {
   return {
     id: part.id || id,
     responses: responses.map((r: any) => {
-      const cleanedMatch = convertCatchAll(r.match);
+      const cleanedMatch = convertCatchAll(r.match.trim());
       const item: any = {
         id: guid(),
         score: r.score === undefined ? 0 : parseFloat(r.score),

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -379,7 +379,7 @@ export function inputMatchToRule(
   case_sensitive: string,
   type: any
 ) {
-  let m = match;
+  let m = match.trim();
 
   // convert * to standard regexp
   if (match === '*') {


### PR DESCRIPTION
Torus will always trim whitespace from student input before matching text strings, so an answer match with extraneous white space will be unmatchable. This has the digest tool trim legacy match strings on migrating answer match rules. 