### PR TITLE
[BUGFIX] targeted feedback fixes for merged pool sections, multi-inputs [MER-3047]

### DIFF
--- a/src/resources/pool.ts
+++ b/src/resources/pool.ts
@@ -282,11 +282,6 @@ const makeUniqueIds = (q: any, nPart: number) => {
               });
             // update input's list of choice idrefs
             inp.choiceIds = inp.choiceIds.map((cid: string) => idMap.get(cid));
-
-            // replace choiceIds in targeted feedback index key
-            q.authoring.targeted = q.authoring.targeted.map(
-              ([[choiceId], respId]: any) => [[idMap.get(choiceId)], respId]
-            );
           }
         });
     }
@@ -295,5 +290,10 @@ const makeUniqueIds = (q: any, nPart: number) => {
   // update all input_refs in stem
   getDescendants(q.stem.content, 'input_ref').forEach(
     (ref) => (ref.id = idMap.get(ref.id))
+  );
+
+  // replace all choiceIds in question-wide targeted feedback index keys
+  q.authoring.targeted = q.authoring.targeted.map(
+    ([[choiceId], respId]: any) => [[idMap.get(choiceId)], respId]
   );
 };

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -215,12 +215,16 @@ function produceTorusEquivalents(
     choices = buildChoices({ children: [item] }, part.id, 'fill_in_the_blank');
     input.choiceIds = choices.map((c: any) => c.id);
 
-    if (!(part.responses as Array<any>).some((r) => r.legacyMatch === '.*')) {
-      part.responses.forEach((r: any) => {
+    // omit correct response from targeted response mapping
+    const correctId = part.responses.find(
+      (r: any) => r.score !== undefined && r.score > 0
+    )?.id;
+    part.responses
+      .filter((r: any) => r.legacyMatch !== '.*' && r.id !== correctId)
+      .forEach((r: any) =>
         // must adjust to match part-qualified choiceIds we generate
-        targeted.push([[part.id + '_' + r.legacyMatch], r.id]);
-      });
-    }
+        targeted.push([[part.id + '_' + r.legacyMatch], r.id])
+      );
   }
 
   if (item.id) {


### PR DESCRIPTION
Migration of section pools now works by merging all questions in the pool into one big multi-input question. Preparing questions for merging involves renaming ids to new, part-qualified ids, including updating the choice Ids used as keys in the targeted feedback mapping. This PR corrects a coding error causing incorrect results when merging more than one multiple choice question with targeted feedback. The code to update the single question-global targeted feedback list needs to occur at the end of the routine, so it operates after all constitutent questions have been processed.

This also fixes targeted feedback listing for multi-input questions to omit the correct answer, same as was done for multiple choice questions. 