### PR TITLE
[BUGFIX] handle math input questions [MER-3053]

### DIFF
--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -199,7 +199,8 @@ function produceTorusEquivalents(
   if (item.type === 'text') {
     part = buildInputPart('text', p, item);
     ensureAtLeastOneCorrectResponse(part);
-    input.inputType = 'text';
+    // text input with math keyboard set => torus math input
+    input.inputType = item.keyboard === 'math' ? 'math' : 'text';
     input.size = item.size;
   } else if (item.type === 'numeric') {
     part = buildInputPart('numeric', p, i);


### PR DESCRIPTION
Migrate legacy math input questions, identified as text input with attribute keyboard="math", to torus math input type.