### PR TITLE
[ENHANCEMENT] handle mixed content within formulas [MER-3067]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -743,10 +743,11 @@ function isSingleLatexString(s: string): boolean {
   return (
     // make sure no internal closing delimiter as for multiple formula
     (trimmed.startsWith('$$') &&
-      trimmed.indexOf('$$') === trimmed.length - 2) ||
+      trimmed.indexOf('$$', 2) === trimmed.length - 2) ||
     (trimmed.startsWith('\\(') &&
-      trimmed.indexOf('\\)') === trimmed.length - 2) ||
-    (trimmed.startsWith('\\[') && trimmed.indexOf('\\]') === trimmed.length - 2)
+      trimmed.indexOf('\\)', 2) === trimmed.length - 2) ||
+    (trimmed.startsWith('\\[') &&
+      trimmed.indexOf('\\]', 2) === trimmed.length - 2)
   );
 }
 

--- a/test/resources/formula-math-test.ts
+++ b/test/resources/formula-math-test.ts
@@ -75,6 +75,7 @@ describe('formulas and mathml', () => {
 
   test('should properly identify and convert latex formulas', () => {
     let s = process('<body><formula>$$\\frac{2}{3}$$</formula></body>');
+    console.log(s);
     expect(s.indexOf('subtype="latex"')).toBeGreaterThan(-1);
     expect(s.indexOf('src="\\frac{2}{3}"')).toBeGreaterThan(-1);
 

--- a/test/resources/formula-math-test.ts
+++ b/test/resources/formula-math-test.ts
@@ -75,7 +75,6 @@ describe('formulas and mathml', () => {
 
   test('should properly identify and convert latex formulas', () => {
     let s = process('<body><formula>$$\\frac{2}{3}$$</formula></body>');
-    console.log(s);
     expect(s.indexOf('subtype="latex"')).toBeGreaterThan(-1);
     expect(s.indexOf('src="\\frac{2}{3}"')).toBeGreaterThan(-1);
 


### PR DESCRIPTION
Migration tool had been assuming legacy `<formula>` element would contain a single MathML, LaTex formula. But some legacy courses include mixed content within a formula block. Have seen: 

- two delimited inline LaTeX expressions (the second to add a boxed theorem number); 
- a rich text formula followed by a delimited inline LaTeX formula (again, second to add a boxed number)
- Two MathML expressions linked by plain text " iff ".

This adjusts to only convert legacy formula to torus formula/formula-inline in the case of a single LaTex or MathML expression. Otherwise leaves it as a callout with rich text. Delimited formulas within callout content will be handled by general handling of formulas in rich text content.