### PR TITLE
[BUGFIX] migrate video captions [MER-3124]

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -164,7 +164,7 @@ export function standardContentManipulations($: any) {
   // representation for how Torus supports them
   DOM.flattenNestedSections($);
   DOM.removeSelfClosing($);
-  DOM.mergeCaptions($);
+  DOM.prependTitles($);
   // Default to block images
   DOM.rename($, 'image', 'img');
   DOM.rename($, 'link', 'a');
@@ -203,6 +203,9 @@ export function standardContentManipulations($: any) {
       $(item).html(`<p>${$(item).html()}</p>`);
     }
   });
+
+  // torus video element has no caption, so add any caption content after
+  DOM.appendCaptions($, 'video');
 
   // Inline images should technically be valid in any Slate model element
   // that supports inline elements, but we're only explicitly handling
@@ -271,8 +274,8 @@ export function standardContentManipulations($: any) {
   $('p>table').remove();
   $('p>title').remove();
   // handle titles of lists
-  DOM.handleLabelledContent($, 'ol');
-  DOM.handleLabelledContent($, 'ul');
+  DOM.handleTitledContent($, 'ol');
+  DOM.handleTitledContent($, 'ul');
 
   DOM.rename($, 'quote', 'blockquote');
   DOM.rename($, 'composite_activity title', 'p');

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -284,6 +284,8 @@ function getHotspots(imageHotspot: any) {
       id: hs.value,
       coords: hs.coords.split(',').map(Number),
       // shape not needed, torus derives from number of coords
+      // includes dummy content to implement choice interface
+      content: [{ id: guid(), type: 'p', children: [{ text: ' ' }] }],
     };
     if (hs.title !== undefined) hotspot.title = hs.title;
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -191,23 +191,24 @@ export function stripElement($: any, selector: string) {
 }
 
 export function mergeTitles($: any) {
-  mergeElement($, 'organization', 'title');
-  mergeElement($, 'sequence', 'title');
-  mergeElement($, 'unit', 'title');
-  mergeElement($, 'module', 'title');
-  mergeElement($, 'section', 'title');
+  mergeElementText($, 'organization', 'title');
+  mergeElementText($, 'sequence', 'title');
+  mergeElementText($, 'unit', 'title');
+  mergeElementText($, 'module', 'title');
+  mergeElementText($, 'section', 'title');
 }
 
-export function mergeCaptions($: any) {
-  handleLabelledContent($, 'table');
-  handleLabelledContent($, 'audio');
-  handleLabelledContent($, 'iframe');
-  handleLabelledContent($, 'youtube');
-  handleLabelledContent($, 'image');
-  handleLabelledContent($, 'video');
+export function prependTitles($: any) {
+  handleTitledContent($, 'table');
+  handleTitledContent($, 'audio');
+  handleTitledContent($, 'iframe');
+  handleTitledContent($, 'youtube');
+  handleTitledContent($, 'image');
+  handleTitledContent($, 'video');
 }
 
-function mergeElement($: any, selector: string, element: string) {
+// move text of child element to same-named attribute
+function mergeElementText($: any, selector: string, element: string) {
   const items = $(selector);
 
   items.each((i: any, elem: any) => {
@@ -217,7 +218,8 @@ function mergeElement($: any, selector: string, element: string) {
   });
 }
 
-export function handleLabelledContent($: any, selector: string) {
+// prepend title content as header before element
+export function handleTitledContent($: any, selector: string) {
   const items = $(selector);
 
   items.each((i: any, elem: any) => {
@@ -226,6 +228,19 @@ export function handleLabelledContent($: any, selector: string) {
 
     if (title) {
       $('<h6><em>' + title + '</em></h6>').insertBefore($(elem));
+    }
+  });
+}
+
+export function appendCaptions($: any, selector: string) {
+  const items = $(selector);
+
+  items.each((i: any, elem: any) => {
+    const captionHtml = $(elem).children('caption').html();
+    $(elem).children().remove('caption');
+
+    if (captionHtml) {
+      $(captionHtml).insertAfter($(elem));
     }
   });
 }

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -609,6 +609,7 @@ export function toJSON(
         elevateCaption('youtube');
         elevateTableCaption();
         elevateCaption('audio');
+        elevateCaption('video');
         elevateTitle('figure');
         elevatePopoverContent();
         unescapeFormulaSrc();

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -609,7 +609,6 @@ export function toJSON(
         elevateCaption('youtube');
         elevateTableCaption();
         elevateCaption('audio');
-        elevateCaption('video');
         elevateTitle('figure');
         elevatePopoverContent();
         unescapeFormulaSrc();

--- a/test/utils/dom-test.ts
+++ b/test/utils/dom-test.ts
@@ -3,7 +3,7 @@ import {
   eliminateLevel,
   stripElement,
   moveAttrToChildren,
-  mergeCaptions,
+  prependTitles,
   isInlineElement,
 } from 'src/utils/dom';
 import * as cheerio from 'cheerio';
@@ -136,7 +136,7 @@ describe('dom mutations', () => {
       xmlMode: true,
     });
 
-    mergeCaptions($);
+    prependTitles($);
 
     expect($.xml()).toContain('<h6><em>A Wonderful Title</em></h6>');
   });
@@ -150,7 +150,7 @@ describe('dom mutations', () => {
       xmlMode: true,
     });
 
-    mergeCaptions($);
+    prependTitles($);
 
     expect($.xml()).not.toContain('<h5>null</h5>');
   });


### PR DESCRIPTION
Video captions were not being migrated. L&P course uses video captions to include links to transcript pages. 

Because torus videos lack captions, this has migration convert video captions into paragraph content following video element. 

Also renames some caption/title related manipulation routines to be clearer on what they do. 