### PR TITLE
[ENHANCEMENT] Migrate LogicLab activities [MER-3127]

### DIFF
--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -70,6 +70,7 @@ export function determineResourceType(file: string): Promise<ResourceType> {
     ) {
       return 'Superactivity';
     }
+    console.log('tag: ' + tag);
     if (tag.indexOf(' logiclab ') !== -1) {
       return 'LogicLab';
     }

--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -12,6 +12,7 @@ import * as Objectives from './objectives';
 import * as Pool from './pool';
 import * as Skills from './skills';
 import * as Superactivity from './superactivity';
+import * as LogicLab from './logiclab';
 
 const minVersions: Record<string, string> = {
   oli_workbook_page: '3_5',
@@ -69,6 +70,9 @@ export function determineResourceType(file: string): Promise<ResourceType> {
     ) {
       return 'Superactivity';
     }
+    if (tag.indexOf(' logiclab ') !== -1) {
+      return 'LogicLab';
+    }
     if (tag.indexOf('oli_discussion') !== -1) {
       return 'Discussion';
     }
@@ -114,6 +118,9 @@ export function create(
   }
   if (t === 'Discussion') {
     return new Discussion.Discussion(file, navigable);
+  }
+  if (t === 'LogicLab') {
+    return new LogicLab.LogicLab(file, navigable);
   }
   return new Other.Other(file, navigable);
 }

--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -70,7 +70,6 @@ export function determineResourceType(file: string): Promise<ResourceType> {
     ) {
       return 'Superactivity';
     }
-    console.log('tag: ' + tag);
     if (tag.indexOf(' logiclab ') !== -1) {
       return 'LogicLab';
     }

--- a/src/resources/logiclab.ts
+++ b/src/resources/logiclab.ts
@@ -11,6 +11,8 @@ import {
 import * as XML from 'src/utils/xml';
 import { ProjectSummary } from 'src/project';
 import { visit } from 'src/utils/xml';
+import * as DOM from 'src/utils/dom';
+import { standardContentManipulations } from './common';
 import {
   getChild,
   getChildren,
@@ -49,7 +51,10 @@ export class LogicLab extends Resource {
     $: any,
     projectSummary: ProjectSummary
   ): Promise<(TorusResource | string)[]> {
-    // no restructuring, just go straight to JSON parse
+    // restructure to handle content elements in description as paragraph content
+    DOM.rename($, 'description', 'p');
+    standardContentManipulations($);
+
     return new Promise((resolve, _reject) => {
       XML.toJSON($.html(), projectSummary, {
         description: true,
@@ -105,12 +110,10 @@ export class LogicLab extends Resource {
         // model is list of content blocks and activity references
         const model: any[] = [];
 
-        // add paragraph with description text
-        const description = getChild(ps, 'description');
+        // insert initial paragraph with description content
+        const description = getChild(ps, 'p');
         if (description) {
-          const text = description.children[0].text;
-          const paragraph = { type: 'p', children: [{ text }] };
-          model.push({ type: 'content', children: [paragraph] });
+          model.push({ type: 'content', children: [description] });
         }
 
         // include each problem with title and activity ref

--- a/src/resources/logiclab.ts
+++ b/src/resources/logiclab.ts
@@ -1,0 +1,171 @@
+import * as Histogram from 'src/utils/histogram';
+import { ItemReference, guid } from 'src/utils/common';
+import {
+  Resource,
+  TorusResource,
+  Summary,
+  Page,
+  defaultCollabSpaceDefinition,
+  Activity,
+} from './resource';
+import * as XML from 'src/utils/xml';
+import { ProjectSummary } from 'src/project';
+import { visit } from 'src/utils/xml';
+import {
+  getChild,
+  getChildren,
+  getDescendants,
+  hint,
+  makeFeedback,
+} from './questions/common';
+
+//
+// LogicLab superactivity descriptor
+//
+// expected to contain one problem set definition containing one or more problem references as follows:
+/*
+    <logiclab id="ps_lab_intro_statements" width="950" height="600">
+      <title>Lab: Statements and Arguments</title>
+      <source>webcontent/logiclab/activity.js</source>
+      <content>
+        <problem_set id="ps_lab_intro_statements" title="Lab: Statements and Arguments" score="all">
+          <problem id="ps_lab_intro_statements_problem_1" title="Problem 1">
+            <item id="standard_form_1" lab="argumentlab" />
+          </problem>
+          <problem id="ps_lab_intro_statements_problem_2" title="Problem 2">
+            <item id="standard_form_2" lab="argumentlab" />
+          </problem>
+        </problem_set>
+      </content>
+    </logiclab>
+*/
+//
+// We effectively treat this like a summative assessment page, converting the
+// the whole problem set to a torus graded page containing references to the
+// problem activities, each of which is converted to a logiclab activity resource
+//
+export class LogicLab extends Resource {
+  translate(
+    $: any,
+    projectSummary: ProjectSummary
+  ): Promise<(TorusResource | string)[]> {
+    // no restructuring, just go straight to JSON parse
+    return new Promise((resolve, _reject) => {
+      XML.toJSON($.html(), projectSummary, {
+        description: true,
+        em: true,
+      }).then((r: any) => {
+        // find the problem_set object, should be just one
+        const ps = getDescendants(r.children, 'problem_set')[0];
+
+        // converts one logiclab problem object to logiclab activity, a thin
+        // wrapper around the lab's internal problem id, specified in item element.
+        const problemToActivity = (problem: any): Activity => {
+          const model = {
+            activity: getChild(problem, 'item').id,
+            authoring: {
+              parts: [
+                {
+                  id: '1',
+                  outOf: problem.worth ? problem.worth : null,
+                  responses: [],
+                  scoringStrategy: 'best',
+                  targets: [],
+                  gradingApproach: 'automatic',
+                  hints: [hint()],
+                },
+              ],
+              previewText: '',
+              transformations: [],
+              version: 1,
+            },
+            feedback: [makeFeedback('incomplete'), makeFeedback('complete')],
+          };
+
+          return {
+            type: 'Activity',
+            subType: 'oli_logic_lab',
+            id: guid(),
+            legacyId: problem.id,
+            legacyPath: this.file,
+            // Friendly title combines problem set and problem number
+            title: ps.title + ' - ' + problem.title,
+            tags: [],
+            unresolvedReferences: [],
+            content: model,
+            objectives: [],
+            warnings: [],
+          };
+        };
+
+        // convert the problems to torus activities
+        const activities = getChildren(ps, 'problem').map(problemToActivity);
+
+        // build content model for page, including problem references
+        // model is list of content blocks and activity references
+        const model: any[] = [];
+
+        // add paragraph with description text
+        const description = getChild(ps, 'description');
+        if (description) {
+          const text = description.children[0].text;
+          const paragraph = { type: 'p', children: [{ text }] };
+          model.push({ type: 'content', children: [paragraph] });
+        }
+
+        // include each problem with title and activity ref
+        activities.forEach((activity: Activity) => {
+          const legacyTitle = activity.title.split(' - ')[1];
+          const title = { type: 'h6', children: [{ text: legacyTitle }] };
+          model.push({ type: 'content', children: [title] });
+
+          model.push({
+            type: 'activity_placeholder',
+            children: [],
+            idref: activity.legacyId,
+          });
+        });
+
+        // create the wrapper workbook page
+        const page: Page = {
+          type: 'Page',
+          id: ps.id,
+          legacyPath: this.file,
+          legacyId: ps.id,
+          title: ps.title,
+          tags: [],
+          unresolvedReferences: [],
+          content: { model },
+          isGraded: true,
+          isSurvey: false,
+          objectives: [],
+          warnings: [],
+          collabSpace: defaultCollabSpaceDefinition(),
+        };
+
+        resolve([page, ...activities]);
+      });
+    });
+  }
+
+  summarize(): Promise<string | Summary> {
+    const foundIds: ItemReference[] = [];
+    const summary: Summary = {
+      type: 'Summary',
+      subType: 'LogicLab',
+      elementHistogram: Histogram.create(),
+      id: '',
+      found: () => foundIds,
+    };
+
+    return new Promise((resolve, reject) => {
+      visit(this.file, (tag: string, attrs: Record<string, unknown>) => {
+        Histogram.update(summary.elementHistogram, tag, attrs);
+      })
+        .then((_result) => {
+          resolve(summary);
+        })
+        .catch((err) => reject(err));
+    });
+  }
+}

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -27,7 +27,8 @@ export type ResourceType =
   | 'Superactivity'
   | 'Skills'
   | 'Other'
-  | 'TemporaryContent';
+  | 'TemporaryContent'
+  | 'LogicLab';
 
 export type TorusResourceType =
   | Hierarchy

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -704,6 +704,6 @@ export function rootTag(file: string): Promise<string> {
     const content: string = fs.readFileSync(file, 'utf-8');
     const dtd = content.substr(content.indexOf('<!DOCTYPE'));
     // normalize whitespace for ease of pattern matching in case split over lines
-    resolve(dtd.substr(0, dtd.indexOf('>') + 1).replace(/\s+/, ' '));
+    resolve(dtd.substr(0, dtd.indexOf('>') + 1).replace(/\s+/g, ' '));
   });
 }

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -703,6 +703,7 @@ export function rootTag(file: string): Promise<string> {
   return new Promise((resolve, _reject) => {
     const content: string = fs.readFileSync(file, 'utf-8');
     const dtd = content.substr(content.indexOf('<!DOCTYPE'));
-    resolve(dtd.substr(0, dtd.indexOf('>') + 1));
+    // normalize whitespace for ease of pattern matching in case split over lines
+    resolve(dtd.substr(0, dtd.indexOf('>') + 1).replace(/\s+/, ' '));
   });
 }


### PR DESCRIPTION
This migrates legacy LogicLab superactivities as used in Logic and Proofs course into torus LogicLab activities. 

In the legacy course, LogicLab descriptors always specify a problem SET of one or more problems from the LogicLab. This migration converts the problem set into a new torus graded page containing references to the individual problems, which are individually converted to torus LogicLab activity resources.