### PR TITLE
[BUG FIX] [MER-3159] fix extraneous trailing backslash in some code block lines

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -12,9 +12,10 @@ export interface HasHistogram {
   elementHistogram: Histogram.ElementHistogram;
 }
 
-// Escapes leading space, tab and backslash, but not newline, for use in code lines
+// Escapes space, tab and backslash, but not newline, for preservation in code lines
 // BACKSLASH TAB could get normalized to BACKSLASH SP, so uses BACKSLASH T instead
-export function escapeLeadingWhiteSpace(s: string) {
+// Strips trailing white space on assumption it is never needed
+export function escapeCodeWhiteSpace(s: string) {
   return s
     .trimEnd()
     .replace(/[ \t\\]/g, (ch) => '\\' + (ch === '\t' ? 'T' : ch));
@@ -36,9 +37,7 @@ export function processCodeblock($: any) {
         .split('\n')
         .map(
           (r: any) =>
-            '<code_line><![CDATA[' +
-            escapeLeadingWhiteSpace(r) +
-            ']]></code_line>'
+            '<code_line><![CDATA[' + escapeCodeWhiteSpace(r) + ']]></code_line>'
         )
         .reduce((s: string, e: string) => s + e);
 
@@ -47,8 +46,7 @@ export function processCodeblock($: any) {
       const html = h
         .split('\n')
         .map(
-          (r: any) =>
-            '<code_line>' + escapeLeadingWhiteSpace(r) + '</code_line>'
+          (r: any) => '<code_line>' + escapeCodeWhiteSpace(r) + '</code_line>'
         )
         .reduce((s: string, e: string) => s + e);
 

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -12,10 +12,12 @@ export interface HasHistogram {
   elementHistogram: Histogram.ElementHistogram;
 }
 
-// Escapes space, tab and backslash, but not newline, for use in code lines
+// Escapes leading space, tab and backslash, but not newline, for use in code lines
 // BACKSLASH TAB could get normalized to BACKSLASH SP, so uses BACKSLASH T instead
-export function escapeWhiteSpace(s: string) {
-  return s.replace(/[ \t\\]/g, (ch) => '\\' + (ch === '\t' ? 'T' : ch));
+export function escapeLeadingWhiteSpace(s: string) {
+  return s
+    .trimEnd()
+    .replace(/[ \t\\]/g, (ch) => '\\' + (ch === '\t' ? 'T' : ch));
 }
 
 export function unescapeWhiteSpace(s: string) {
@@ -34,7 +36,9 @@ export function processCodeblock($: any) {
         .split('\n')
         .map(
           (r: any) =>
-            '<code_line><![CDATA[' + escapeWhiteSpace(r) + ']]></code_line>'
+            '<code_line><![CDATA[' +
+            escapeLeadingWhiteSpace(r) +
+            ']]></code_line>'
         )
         .reduce((s: string, e: string) => s + e);
 
@@ -42,7 +46,10 @@ export function processCodeblock($: any) {
     } else {
       const html = h
         .split('\n')
-        .map((r: any) => '<code_line>' + escapeWhiteSpace(r) + '</code_line>')
+        .map(
+          (r: any) =>
+            '<code_line>' + escapeLeadingWhiteSpace(r) + '</code_line>'
+        )
         .reduce((s: string, e: string) => s + e);
 
       $(item).html(html);


### PR DESCRIPTION
Codeblock lines with trailing whitespace were coming out of migration with extraneous backslashes at the end. This was due to a flaw in the escaping/unescaping of white space done to preserve whitespace through various whitespace-normalizing parses the tool applies. This fixes by escaping leading and internal whitespace only, stripping trailing white space in codeblock lines on assumption it is never needed. 