### PR TITLE
[BUGFIX] [MER-3226] map code language values to torus versions for syntax coloring

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -215,8 +215,15 @@ export function standardContentManipulations($: any) {
   // Inline images should technically be valid in any Slate model element
   // that supports inline elements, but we're only explicitly handling
   // converting images in paragraphs and links (anchors).
+
   DOM.rename($, 'codeblock', 'code');
   DOM.renameAttribute($, 'code', 'syntax', 'language');
+  // Torus code language value must be exact "pretty" name shown in dropdown
+  $('code').each((i: any, item: any) => {
+    const lang = $(item).attr('language');
+    if (lang)
+      $(item).attr('language', lang === 'cpp' ? 'C++' : capitalize(lang));
+  });
 
   // Certain elements are not currently (and some may never be) supported
   // in Torus, so we remove them.  In this respect, OLI course conversion


### PR DESCRIPTION
Migration was not getting syntax highlighting on python codeblocks. Was passing through the legacy language attribute value "python" unchanged.  It seems torus code language ids are the "pretty" capitalized strings displayed in the language choice dropdown menu and lookup is case-sensitive. So in this case language value must be "Python" to work. This converts language values appropriately to get syntax highlighting.

Legacy DTD has only a small number of syntax values defined, so don't have to worry about mapping "sql" => "SQL" or "typescript" => "TypeScript", but do have to map "cpp" => "C++".