### PR TITLE
[BUGFIX] [MER-3232] Ensure page_links have purpose value

### DIFF
--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -35,6 +35,8 @@ export function buildMulti(
         transformations.push(Common.shufflePartTransformation(part.id));
       }
     }
+  } else {
+    console.log(`Mismatch: ${items.length} inputs; ${parts.length} parts`);
   }
 
   const transformation = Common.getChild(question, 'transformation');

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -150,8 +150,8 @@ export class WorkbookPage extends Resource {
       const idref = $(elem).attr('idref');
       const purpose = $(elem).attr('purpose');
       if (
-        purpose !== null &&
-        purpose !== undefined &&
+        purpose === null ||
+        purpose === undefined ||
         (validPurposes as any)[purpose] === undefined
       ) {
         $(elem).attr('purpose', 'none');


### PR DESCRIPTION
Post-test in one course was not loading because link in source workbook page did not have a purpose, and torus requires a purpose to render the link. This corrects logic to ensure page links always have a purpose, filling in "none" in the case where source has none specified. 