### PR TITLE
[BUGFIX] [MER-3245] handle inline code in table headers

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -157,14 +157,14 @@ export function standardContentManipulations($: any) {
   // <code> is a mixed element, we only want to translate the inline <code>
   // instances to <em> elements.  The block level <code> will get converted
   // to Torus code model elements.
-  ['p', 'li', 'td', 'th', 'choice', 'hint', 'feedback'].forEach((e) => {
+  ['p', 'li', 'td', 'choice', 'hint', 'feedback'].forEach((e) => {
     $(`${e} code`).each((i: any, item: any) => $(item).attr('style', 'code'));
     DOM.rename($, `${e} code`, 'em');
   });
-  // can also be code with explicit inline style
+  // also convert code elements with explicit inline style
   $('code[style="inline"]').each((i: any, item: any) => {
     $(item).attr('style', 'code');
-    $(item).name = 'em';
+    item.tagName = 'em';
   });
 
   // One course wrapped mathML in code for style; won't work in torus block code box

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -157,9 +157,14 @@ export function standardContentManipulations($: any) {
   // <code> is a mixed element, we only want to translate the inline <code>
   // instances to <em> elements.  The block level <code> will get converted
   // to Torus code model elements.
-  ['p', 'li', 'td', 'choice', 'hint', 'feedback'].forEach((e) => {
+  ['p', 'li', 'td', 'th', 'choice', 'hint', 'feedback'].forEach((e) => {
     $(`${e} code`).each((i: any, item: any) => $(item).attr('style', 'code'));
     DOM.rename($, `${e} code`, 'em');
+  });
+  // can also be code with explicit inline style
+  $('code[style="inline"]').each((i: any, item: any) => {
+    $(item).attr('style', 'code');
+    $(item).name = 'em';
   });
 
   // One course wrapped mathML in code for style; won't work in torus block code box

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -692,6 +692,7 @@ export class Formative extends Resource {
         em: true,
         li: true,
         td: true,
+        th: true,
         choice: true,
         stem: true,
         hint: true,

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -270,7 +270,6 @@ function produceTorusEquivalents(
   }
   // can apparently have minimal question w/implied input but no input id used anywhere
   if (!input.id) {
-    console.warn(`${questionId} part ${i + 1} ${item.type}: no input id found`);
     input.id = `${questionId}-${i + 1}`;
   }
 

--- a/src/resources/summative.ts
+++ b/src/resources/summative.ts
@@ -140,6 +140,7 @@ export class Summative extends Resource {
         em: true,
         li: true,
         td: true,
+        th: true,
       }).then((r: any) => {
         const legacyId = r.children[0].id;
 

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -232,6 +232,7 @@ export class WorkbookPage extends Resource {
         em: true,
         li: true,
         td: true,
+        th: true,
         material: true,
         anchor: true,
         translation: true,

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -599,6 +599,7 @@ export function toJSON(
         ensureNotEmpty('formula_inline');
         ensureNotEmpty('callout_inline');
         ensureTextDoesNotSurroundBlockElement('td');
+        ensureTextDoesNotSurroundBlockElement('th');
         ensureTextDoesNotSurroundBlockElement('dd');
         ensureTextDoesNotSurroundBlockElement('dt');
         ensureTextDoesNotSurroundBlockElement('li');


### PR DESCRIPTION
This is a fix for migrating certain content appearing in Principles of Computing course, which makes extensive use of inline code formatting, including some where inline code-styled text (e.g. variable names) is intermixed with other text content within table headers. These were getting turned into block code elements. The general fix is to respect the `style="inline"` attribute of the legacy `code` element.