### PR TITLE
[BUGFIX] [MER-3228] Don't set submitPerPart if q has math input part

### DIFF
--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -73,11 +73,14 @@ export function buildMulti(
         .map(iRefToPart)
         .filter((p) => p !== undefined);
 
+  // set unless a part uses math keyboard, which doesn't work w/that option
+  const submitPerPart = !inputs.some((i) => i.inputType === 'math');
+
   return {
     stem,
     choices: allChoices,
     inputs,
-    submitPerPart: true,
+    submitPerPart,
     authoring: {
       targeted: allTargeted,
       parts: orderedParts,


### PR DESCRIPTION
Migration tool normally sets the submitPerPart option on multi-inputs. With this option, question omits a Submit button, automatically submitting any non-empty answer contents on Enter key or loss of focus. But activating math input keyboard apparently interferes with torus' handling these events, leaving no way to submit answer when this option is used. So, don't set it if question includes any math input items.