### PR TITLE
[BUGFIX] [MER-3248] handle emphasis style

### DIFF
--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -71,6 +71,8 @@ function inlineAttrName(attrs: Record<string, unknown>) {
     return 'term';
   } else if (attrs['style'] === 'line-through') {
     return 'strikethrough';
+  } else if (attrs['style'] === 'emphasis') {
+    return 'strong';
   } else {
     if (attrs['style']) console.log('unknown inline style: ' + attrs['style']);
     return 'strong';


### PR DESCRIPTION
Legacy allowed "emphasis" inline style, tool was not handling this. 