### PR TITLE
[BUG FIX] [MER-3319] [MER-3289] Uningestible output for print_cert resource

### DIFF
--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -78,7 +78,6 @@ export function determineResourceType(file: string): Promise<ResourceType> {
       return 'Discussion';
     }
 
-    console.log('Unrecognized resource type: ' + tag.split(' ')[1]);
     return 'Other';
   });
 }

--- a/src/resources/create.ts
+++ b/src/resources/create.ts
@@ -67,7 +67,7 @@ export function determineResourceType(file: string): Promise<ResourceType> {
       tag.indexOf('oli-linked-activity') !== -1 ||
       tag.indexOf('cmu-ctat-tutor') !== -1 ||
       tag.indexOf(' ctat ') !== -1 ||
-      tag.indexOf('bio_sim')
+      tag.indexOf('bio_sim') !== -1
     ) {
       return 'Superactivity';
     }
@@ -78,6 +78,7 @@ export function determineResourceType(file: string): Promise<ResourceType> {
       return 'Discussion';
     }
 
+    console.log('Unrecognized resource type: ' + tag.split(' ')[1]);
     return 'Other';
   });
 }

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -196,7 +196,7 @@ function determineActivityDefaults(
     case 'bio_sim':
       return {
         subType: 'oli_embedded',
-        base: 'embedded',
+        base: 'bio_simulator',
         src: 'simulator.html',
       };
     case 'repl':


### PR DESCRIPTION
Fixes two errors in the attempt at bio_sim superactivity support:

1. fixes coding error in testing resource type introduced with bio_sim case.  Led to error on handling a few little-used resource types, including any unknown types like print_cert.

2. corrects base filled in for bio_sim superactivity.