### PR TITLE
[BUG FIX] [MER-3383] [MER-3384] [MER-3386] Handle titles of alternatives, examples, inquiry

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -311,7 +311,6 @@ export function standardContentManipulations($: any) {
     const typeHeader = typeId === 'tosumup' ? 'To Sum Up' : capitalize(typeId);
     $(item).prepend(`<em>${typeHeader}...</em>`);
   });
-  // DOM.rename($, 'pullout title', 'p');
   DOM.rename($, 'pullout', 'blockquote');
 
   $('example').each((i: any, item: any) => {

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -174,7 +174,8 @@ export function standardContentManipulations($: any) {
   // representation for how Torus supports them
   DOM.flattenNestedSections($);
   DOM.removeSelfClosing($);
-  DOM.prependTitles($);
+  DOM.titlesToContent($);
+
   // Default to block images
   DOM.rename($, 'image', 'img');
   DOM.rename($, 'link', 'a');
@@ -290,9 +291,6 @@ export function standardContentManipulations($: any) {
 
   $('p>table').remove();
   $('p>title').remove();
-  // handle titles of lists
-  DOM.handleTitledContent($, 'ol');
-  DOM.handleTitledContent($, 'ul');
 
   DOM.rename($, 'quote', 'blockquote');
 
@@ -335,7 +333,6 @@ export function standardContentManipulations($: any) {
   DOM.renameAttribute($, 'video source', 'type', 'contenttype');
   DOM.renameAttribute($, 'video source', 'src', 'url');
   DOM.renameAttribute($, 'video', 'type', 'contenttype');
-
   DOM.renameAttribute($, 'audio', 'type', 'audioType');
 
   DOM.rename($, 'extra', 'popup');

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -295,7 +295,6 @@ export function standardContentManipulations($: any) {
   DOM.handleTitledContent($, 'ul');
 
   DOM.rename($, 'quote', 'blockquote');
-  DOM.rename($, 'composite_activity title', 'p');
 
   DOM.renameAttribute(
     $,
@@ -312,7 +311,7 @@ export function standardContentManipulations($: any) {
     const typeHeader = typeId === 'tosumup' ? 'To Sum Up' : capitalize(typeId);
     $(item).prepend(`<em>${typeHeader}...</em>`);
   });
-  DOM.rename($, 'pullout title', 'p');
+  // DOM.rename($, 'pullout title', 'p');
   DOM.rename($, 'pullout', 'blockquote');
 
   $('example').each((i: any, item: any) => {
@@ -322,9 +321,7 @@ export function standardContentManipulations($: any) {
       $(item).attr('id') === undefined ? guid() : $(item).attr('id')
     );
   });
-
   DOM.rename($, 'example', 'group');
-  DOM.rename($, 'group title', 'p');
 
   $('group').each((i: any, item: any) => {
     $(item).attr('layout', 'vertical');

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -524,14 +524,14 @@ function handleDefinitions($: any) {
 }
 
 function handleInquiry($: any) {
-  DOM.rename($, 'inquiry title', 'p');
+  // Title already handled
   // Insert "Question" and "Answer" headers
-  $('inquiry question').before('<h4><em>Question</em></h4>');
+  $('inquiry question').before('<h5><em>Question</em></h5>');
   $('inquiry answer').before('<h5><em>Answer</em></h5>');
   DOM.rename($, 'inquiry question', 'p');
   DOM.rename($, 'inquiry answer', 'p');
 
-  DOM.stripElement($, 'inquiry');
+  DOM.rename($, 'inquiry', 'group');
 }
 
 function sideBySideMaterials($: any) {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -199,12 +199,18 @@ export function mergeTitles($: any) {
 }
 
 export function prependTitles($: any) {
+  // These have title content inserted before element
   handleTitledContent($, 'table');
   handleTitledContent($, 'audio');
   handleTitledContent($, 'iframe');
   handleTitledContent($, 'youtube');
   handleTitledContent($, 'image');
   handleTitledContent($, 'video');
+  // For these, title content goes inside the element
+  replaceTitle($, 'example');
+  replaceTitle($, 'alternative');
+  replaceTitle($, 'composite_activity');
+  replaceTitle($, 'pullout');
 }
 
 // move text of child element to same-named attribute
@@ -218,7 +224,7 @@ function mergeElementText($: any, selector: string, element: string) {
   });
 }
 
-// prepend title content as header before element
+// insert title content as header before element
 export function handleTitledContent($: any, selector: string) {
   const items = $(selector);
 
@@ -226,9 +232,19 @@ export function handleTitledContent($: any, selector: string) {
     const title = $(elem).children('title').html();
     $(elem).children().remove('title');
 
-    if (title) {
+    if (title && title !== 'Title') {
       $('<h6><em>' + title + '</em></h6>').insertBefore($(elem));
     }
+  });
+}
+
+// replace title element with bold header to look like title
+export function replaceTitle($: any, selector: string) {
+  const items = $(`${selector}>title`);
+  items.each((i: any, elem: any) => {
+    const titleText = $(elem).text().trim();
+    if (titleText.toLowerCase() === 'title') $(elem).remove();
+    else $(elem).replaceWith(`<h6><em>${titleText}</em></h6>`);
   });
 }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -198,17 +198,6 @@ export function mergeTitles($: any) {
   mergeElementText($, 'section', 'title');
 }
 
-// move text of child element to same-named attribute
-function mergeElementText($: any, selector: string, element: string) {
-  const items = $(selector);
-
-  items.each((i: any, elem: any) => {
-    const text = $(elem).children(element).text();
-    $(elem).attr(element, text);
-    $(elem).children().remove(element);
-  });
-}
-
 export function titlesToContent($: any) {
   // These have title content inserted before element
   handleTitledContent($, 'table');
@@ -226,6 +215,18 @@ export function titlesToContent($: any) {
   replaceTitle($, 'alternative');
   replaceTitle($, 'composite_activity');
   replaceTitle($, 'pullout');
+  replaceTitle($, 'inquiry', 'INQUIRY: ');
+}
+
+// move text of child element to same-named attribute
+function mergeElementText($: any, selector: string, element: string) {
+  const items = $(selector);
+
+  items.each((i: any, elem: any) => {
+    const text = $(elem).children(element).text();
+    $(elem).attr(element, text);
+    $(elem).children().remove(element);
+  });
 }
 
 // insert title content as header before element
@@ -243,12 +244,12 @@ export function handleTitledContent($: any, selector: string) {
 }
 
 // replace title element with bold header to look like title
-export function replaceTitle($: any, selector: string) {
+export function replaceTitle($: any, selector: string, prefix: string = '') {
   const items = $(`${selector}>title`);
   items.each((i: any, elem: any) => {
     const titleText = $(elem).text().trim();
     if (titleText.toLowerCase() === 'title') $(elem).remove();
-    else $(elem).replaceWith(`<h6><em>${titleText}</em></h6>`);
+    else $(elem).replaceWith(`<h6><em>${prefix}${titleText}</em></h6>`);
   });
 }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -198,21 +198,6 @@ export function mergeTitles($: any) {
   mergeElementText($, 'section', 'title');
 }
 
-export function prependTitles($: any) {
-  // These have title content inserted before element
-  handleTitledContent($, 'table');
-  handleTitledContent($, 'audio');
-  handleTitledContent($, 'iframe');
-  handleTitledContent($, 'youtube');
-  handleTitledContent($, 'image');
-  handleTitledContent($, 'video');
-  // For these, title content goes inside the element
-  replaceTitle($, 'example');
-  replaceTitle($, 'alternative');
-  replaceTitle($, 'composite_activity');
-  replaceTitle($, 'pullout');
-}
-
 // move text of child element to same-named attribute
 function mergeElementText($: any, selector: string, element: string) {
   const items = $(selector);
@@ -222,6 +207,25 @@ function mergeElementText($: any, selector: string, element: string) {
     $(elem).attr(element, text);
     $(elem).children().remove(element);
   });
+}
+
+export function titlesToContent($: any) {
+  // These have title content inserted before element
+  handleTitledContent($, 'table');
+  handleTitledContent($, 'audio');
+  handleTitledContent($, 'iframe');
+  handleTitledContent($, 'youtube');
+  handleTitledContent($, 'image');
+  handleTitledContent($, 'video');
+  // legacy allowed titles on lists
+  handleTitledContent($, 'ol');
+  handleTitledContent($, 'ul');
+
+  // For these, title content remains inside the element
+  replaceTitle($, 'example');
+  replaceTitle($, 'alternative');
+  replaceTitle($, 'composite_activity');
+  replaceTitle($, 'pullout');
 }
 
 // insert title content as header before element

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -244,7 +244,7 @@ export function handleTitledContent($: any, selector: string) {
 }
 
 // replace title element with bold header to look like title
-export function replaceTitle($: any, selector: string, prefix: string = '') {
+export function replaceTitle($: any, selector: string, prefix = '') {
   const items = $(`${selector}>title`);
   items.each((i: any, elem: any) => {
     const titleText = $(elem).text().trim();

--- a/test/convert-test.ts
+++ b/test/convert-test.ts
@@ -134,7 +134,7 @@ it('should convert content with purpose to groups', async () => {
                 id: expect.any(String),
                 children: expect.arrayContaining([
                   expect.objectContaining({
-                    type: 'p',
+                    type: 'h6',
                     children: expect.arrayContaining([
                       expect.objectContaining({ text: 'Example Title' }),
                     ]),

--- a/test/resources/workbook-test.ts
+++ b/test/resources/workbook-test.ts
@@ -68,8 +68,8 @@ describe('convert workbook', () => {
                   },
                   children: [
                     {
-                      children: [{ text: 'Example Title' }],
-                      type: 'p',
+                      children: [{ strong: true, text: 'Example Title' }],
+                      type: 'h6',
                     },
                     {
                       type: 'p',

--- a/test/utils/dom-test.ts
+++ b/test/utils/dom-test.ts
@@ -3,7 +3,7 @@ import {
   eliminateLevel,
   stripElement,
   moveAttrToChildren,
-  prependTitles,
+  titlesToContent,
   isInlineElement,
 } from 'src/utils/dom';
 import * as cheerio from 'cheerio';
@@ -136,7 +136,7 @@ describe('dom mutations', () => {
       xmlMode: true,
     });
 
-    prependTitles($);
+    titlesToContent($);
 
     expect($.xml()).toContain('<h6><em>A Wonderful Title</em></h6>');
   });
@@ -150,7 +150,7 @@ describe('dom mutations', () => {
       xmlMode: true,
     });
 
-    prependTitles($);
+    titlesToContent($);
 
     expect($.xml()).not.toContain('<h5>null</h5>');
   });


### PR DESCRIPTION
Title elements on alternatives were not being migrated, causing errors (seen in Alvin Statistics). This PR processes titles included on alternatives. 

Also, title elements on some other elements, prominently examples, were being converted to ordinary paragraphs so they rendered with no distinctive styling [MER-3384] This PR changes to use a common routine for titles on all these elements to ensure synthesized titles are consistently rendered in a distinctive bold style.

This also improves Inquiry formatting [MER-3386] by using same method to style title distinctively, adding "INQUIRY: " prefix, and, in an independently requested tweak, changing to use same size for Question and Answer headers.

[MER-3384]: https://eliterate.atlassian.net/browse/MER-3384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3386]: https://eliterate.atlassian.net/browse/MER-3386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ