### PR TITLE
[ENHANCEMENT] [MER-3389] Handle pullouts containing alternatives

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -303,6 +303,9 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'composite_activity', 'group');
 
+  // Strip pullout level if it contains alternatives, won't work.
+  DOM.eliminateLevel($, 'pullout:has(alternatives)');
+
   DOM.renameAttribute($, 'pullout', 'type', 'pullouttype');
   $('pullout[pullouttype]').each((i: number, item: any) => {
     const typeId = $(item).attr('pullouttype');
@@ -454,13 +457,14 @@ function handleConjugations($: any) {
 }
 
 function handleAlternatives($: cheerio.Root) {
+  // move default element into attribute for convenience
+  DOM.mergeElementText($, 'alternatives', 'default');
+
   $('alternatives').each((i, alternatives) => {
     $(alternatives).attr('strategy', 'user_section_preference');
 
-    // get default alternative value and remove default child element
-    const defaultValue = $('default', alternatives).text();
-    $(alternatives).children('default').remove();
-
+    // handle default alternative value
+    const defaultValue = $(alternatives).attr('default');
     if (defaultValue) {
       // the default alternative in torus is just the first one in the list
       // so move the default item to first position

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -457,14 +457,13 @@ function handleConjugations($: any) {
 }
 
 function handleAlternatives($: cheerio.Root) {
-  // move default element into attribute for convenience
-  DOM.mergeElementText($, 'alternatives', 'default');
-
   $('alternatives').each((i, alternatives) => {
     $(alternatives).attr('strategy', 'user_section_preference');
 
-    // handle default alternative value
-    const defaultValue = $(alternatives).attr('default');
+    // get default alternative value and remove default child element
+    const defaultValue = $('default', alternatives).text();
+    $(alternatives).children('default').remove();
+
     if (defaultValue) {
       // the default alternative in torus is just the first one in the list
       // so move the default item to first position

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -219,7 +219,7 @@ export function titlesToContent($: any) {
 }
 
 // move text of child element to same-named attribute
-export function mergeElementText($: any, selector: string, element: string) {
+function mergeElementText($: any, selector: string, element: string) {
   const items = $(selector);
 
   items.each((i: any, elem: any) => {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -219,7 +219,7 @@ export function titlesToContent($: any) {
 }
 
 // move text of child element to same-named attribute
-function mergeElementText($: any, selector: string, element: string) {
+export function mergeElementText($: any, selector: string, element: string) {
   const items = $(selector);
 
   items.each((i: any, elem: any) => {


### PR DESCRIPTION
Alvin statistics course contains alternatives within pullouts to conform to a convention that statistical package instructions are rendered as pullouts. This won't work in torus since pullouts and alternatives are block elements. In addition the alternative content itself is generally complex, with multiple paragraphs and/or bulleted lists. 

This simple solution just eliminates the pullout level if it contains alternatives. This suffices to get the content legibly rendered.