### PR TITLE
[ENHANCEMENT] [MER-3395] set custom scoring flags on activity models where needed

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -542,17 +542,19 @@ export function titleActivity(
   return pagePart + '-' + itemPart;
 }
 
+// add optional attributes to flag custom scoring to torus authoring
 export function setCustomScoringFlags(model: any, subType: string) {
-  const parts = model.authoring.parts;
-  if (
-    parts.some((p: any) => p.responses.some((r: any) => r.score && r.score > 1))
-  ) {
-    parts.forEach(
-      (p: any) => (p.outOf = Math.max(p.responses.map((r: any) => r.score)))
-    );
-    // multi-inputs also use an activity-wide flag
+  const hasCustomPoints = model.authoring.parts.some(
+    (p: any) => Common.getOutOfPoints(p) > 1
+  );
+  if (hasCustomPoints) {
+    // For multi-part questions, authoring detects custom by activity-wide flag
     if (['oli_multi_input', 'oli_response_multi'].includes(subType))
       model.customScoring = true;
+    // set outOf points, which suffices to signal custom for all others
+    model.authoring.parts.forEach(
+      (p: any) => (p.outOf = Common.getOutOfPoints(p))
+    );
   }
 }
 

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -472,6 +472,9 @@ export function toActivity(
       : 'oli_multi_input';
   }
 
+  // add optional custom scoring attributes to model if needed
+  setCustomScoringFlags(model, activity.subType);
+
   // collect refs from any internal links in stem content
   const links: any[] = Common.getDescendants(model.stem?.content, 'a');
   links.forEach((a: any) => {
@@ -537,6 +540,20 @@ export function titleActivity(
   if (itemPart.startsWith(pagePart)) return itemPart;
 
   return pagePart + '-' + itemPart;
+}
+
+export function setCustomScoringFlags(model: any, subType: string) {
+  const parts = model.authoring.parts;
+  if (
+    parts.some((p: any) => p.responses.some((r: any) => r.score && r.score > 1))
+  ) {
+    parts.forEach(
+      (p: any) => (p.outOf = Math.max(p.responses.map((r: any) => r.score)))
+    );
+    // multi-inputs also use an activity-wide flag
+    if (['oli_multi_input', 'oli_response_multi'].includes(subType))
+      model.customScoring = true;
+  }
 }
 
 function constructObjectives(parts: any): any {

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -390,3 +390,7 @@ export function ensureThree(hints?: any[]) {
   }
   return hints;
 }
+
+export function getOutOfPoints(part: any) {
+  return Math.max(...part.responses.map((r: any) => r?.score ?? 0));
+}


### PR DESCRIPTION
This adds flags used by torus authoring to show the Custom score authoring interface for questions with non-default point values. Failure to do this meant the authoring did not show the true point values being passed through, leading to problems. However, this change is no longer so urgent since torus authoring was changed to recognize "implicit" custom scoring indicated only by the presence of non-default point values (see https://github.com/Simon-Initiative/oli-torus/pull/4877). However it can only help prevent errors to include the explicit settings used by the newer Custom-score-handling code. 