### PR TITLE
[ENHANCEMENT] [MER-3400] adjust submit and compare to require non-blank input

### DIFF
--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -186,7 +186,7 @@ export function buildCATAPart(question: any) {
         // legacy match pattern to be translated later on
         rule: cleanedMatch,
         legacyMatch: cleanedMatch,
-        namremoveSetOpse: r.name,
+        name: r.name,
         feedback: {
           id: guid(),
           content: Common.getFeedbackModel(r),

--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -186,7 +186,7 @@ export function buildCATAPart(question: any) {
         // legacy match pattern to be translated later on
         rule: cleanedMatch,
         legacyMatch: cleanedMatch,
-        name: r.name,
+        namremoveSetOpse: r.name,
         feedback: {
           id: guid(),
           content: Common.getFeedbackModel(r),

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -342,7 +342,6 @@ export function buildTextPart(id: string, question: any) {
       console.log('response with no match. Treating as *');
       r.match = '*';
     }
-    const cleanedMatch = convertCatchAll(r.match.trim());
     const item: any = {
       id: guid(),
       score: r.score === undefined ? 0 : parseFloat(r.score),

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -278,14 +278,8 @@ export function getFeedbackModel(response: any) {
   return ensureParagraphs(feedback.children);
 }
 
-const getResponseFeedbacks = (r: any) => {
-  try {
-    return r.children.filter((c: any) => c.type === 'feedback');
-  } catch (e) {
-    console.log('getResponseFeedbacks error ' + JSON.stringify(r, null, 2));
-    return [];
-  }
-};
+const getResponseFeedbacks = (r: any) =>
+  r.children.filter((c: any) => c.type === 'feedback');
 
 export const maybeBuildPartExplanation = (responses: any[]) => {
   // explanation will be built from the first response that contains multiple feedbacks

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -347,7 +347,6 @@ export function buildTextPart(id: string, question: any) {
       id: guid(),
       score: r.score === undefined ? 0 : parseFloat(r.score),
       rule: inputMatchToRule(r.match, 'false', 'text'),
-      legacyMatch: cleanedMatch,
       feedback: {
         id: guid(),
         content: maybe(r.children[0]).caseOf({

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -397,7 +397,6 @@ export function ensureThree(hints?: any[]) {
   return hints;
 }
 
-
 // modify responses for submit and compare question to require non-blank answer
 // returns JSON-form legacy response list to be converted to torus form
 export function adjustSubmitCompareResponses(origResponses: any[]) {
@@ -421,5 +420,4 @@ export function adjustSubmitCompareResponses(origResponses: any[]) {
 
 export function getOutOfPoints(part: any) {
   return Math.max(...part.responses.map((r: any) => r?.score ?? 0));
-
 }


### PR DESCRIPTION
Legacy submit and compares were being approximated by torus text input questions in which every answer was correct, but this allows blank submissions to get the answer feedback to compare.  In response to requests from LEs, this adjusts the torus output for a legacy submit and compare question to use a regular expression rule to ensure that blank submission is not accepted as correct. With this adjustment, blank submissions will get incorrect (red) colored feedback "Please enter a response".  

The regex .+ works for detecting non-blank answers because torus trims whitespace before evaluating. This crude method still allows a nonsensical or one-character entry. But at least prompts students not to simply hit "submit" on an empty text box and more closely matches legacy submit and compare behavior. 