### PR TITLE
[ENHANCEMENT] [MER-3424] strip alternative level from feedback

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -303,6 +303,13 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'composite_activity', 'group');
 
+  // Strip alternatives within feedback/explanation, won't work.
+  // Shows all possible content, OK if they are titled as in cases we have
+  DOM.eliminateLevel($, 'feedback alternatives');
+  DOM.eliminateLevel($, 'feedback alternative');
+  DOM.eliminateLevel($, 'explanation alternatives');
+  DOM.eliminateLevel($, 'explanation alternative');
+
   // Strip pullout level if it contains alternatives, won't work.
   DOM.eliminateLevel($, 'pullout:has(alternatives)');
 

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -329,14 +329,15 @@ export function buildTextPart(id: string, question: any) {
   const skillrefs = getChildren(part, 'skillref');
   let legacyResponses = getChildren(part, 'response');
 
-  if (isSubmitAndCompare(question)) {
-    legacyResponses = adjustSubmitCompareResponses(legacyResponses);
-  }
-
   if (legacyResponses.length === 0) {
     console.log(`${id}: no response rules. Treating all responses as correct.`);
     legacyResponses = [{ match: '*', score: '1', children: [] }];
   }
+
+  if (isSubmitAndCompare(question)) {
+    legacyResponses = adjustSubmitCompareResponses(legacyResponses);
+  }
+
   const responses = legacyResponses.map((r: any) => {
     if (r.match === undefined) {
       console.log('response with no match. Treating as *');


### PR DESCRIPTION
This removes alternatives structure where it occurs in feedback or explanations (used for submit and compare) because that doesn't work in torus. The effect is that all alternatives are included, preceded by their title if present. (Alternative titles are included in the statistics courses giving rise to this issue). The migrated feedback may well need to be reviewed and edited, but it gets through migration into an acceptable structure. 

This also takes the opportunity to relocate the adjusting of submit and compare to handle the case of questions with no responses, which arose in the Alvin statistics course motivating the current enhancement. 