### PR TITLE
[ENHANCEMENT] [MER-3615] handle CTAT tutors using sequence files (Genetics)

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -96,7 +96,7 @@ export function transformToFlatDirectory(
   const paths = findFromDOM($, filePath);
 
   const isWebBundleElement = (e: any) =>
-    ['link', 'iframe', 'asset'].includes($(e)[0].name) ||
+    ['link', 'iframe', 'asset', 'interface'].includes($(e)[0].name) ||
     ($(e)[0].name === 'source' && $(e).parent()[0].name === 'embed_activity');
 
   Object.keys(paths).forEach((assetReference: any) => {
@@ -464,16 +464,19 @@ function generateNewName(
   }
 }
 
-// Turns a media asset reference that is relative to a particular course
-// XML document, into a reference that is relative to the root directory
-// of the project
+// Turns a media asset reference that may be relative to a particular course
+// XML document into a full path to file in project directory
 export function resolve(reference: MediaItemReference): string {
   let dir = path.dirname(reference.filePath);
 
+  // Ref of form 'webcontent/foo/bar' denotes file within top-level
+  // webcontent directory so is relative to project content directory
   if (reference.assetReference.startsWith('webcontent')) {
+    // Heuristic for finding path to project content directory assumes
+    // no 'content' directory anywhere else within content tree
     dir =
-      reference.filePath.slice(0, reference.filePath.lastIndexOf('content')) +
-      'content/';
+      reference.filePath.slice(0, reference.filePath.lastIndexOf('/content/')) +
+      '/content/';
   }
 
   const assetRef = removeQueryParams(reference.assetReference);

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -10,6 +10,14 @@ import { guid } from 'src/utils/common';
 import * as XML from 'src/utils/xml';
 import { Maybe } from 'tsmonad';
 import { ProjectSummary } from 'src/project';
+import {
+  getWebBundleUrl,
+  MediaSummary,
+  resolve,
+  transformToFlatDirectory,
+} from 'src/media';
+import * as DOM from 'src/utils/dom';
+import * as fs from 'fs';
 
 export class Superactivity extends Resource {
   flagContentWarnigns(_$: any, _page: Page) {
@@ -47,8 +55,10 @@ export class Superactivity extends Resource {
             file.includes('x-cmu-ctattutors') ||
             navigable
           ) {
+            // x-cmu-ctattutors using sequence files need special processing
+            const modelXml = handleCtatSequenceFiles(xml, file, projectSummary);
             const activity = toActivity(
-              toActivityModel(defaults.base, defaults.src, title, xml),
+              toActivityModel(defaults.base, defaults.src, title, modelXml),
               guid(),
               defaults.subType,
               title
@@ -268,4 +278,87 @@ function toActivityModel(
       previewText: '',
     },
   };
+}
+
+// Some x-cmu-ctattutors have <interface> element referencing an xml "sequence"
+// file defining a set of problems rather than an HTML file to be loaded. These
+// sequence files contain relative URL references that must be translated, but
+// are not resource files we would otherwise handle, rather just webcontent files.
+// Here we construct torus variant sequence file with translated URLs and add it
+// to the webcontent tree, adjusting the sequence file reference in the given
+// modelXML to point to the torus variant. Because superactivity code detects
+// by url ending in "/sequence.xml" we put it in /torus/ subdir of original file
+// Returns: possibly modified modelXml
+function handleCtatSequenceFiles(
+  modelXml: string,
+  filePath: string,
+  project: ProjectSummary
+): string {
+  const interfaceRef = modelXml.substring(
+    modelXml.indexOf('<interface>') + '<interface>'.length,
+    modelXml.indexOf('</interface>')
+  );
+  if (interfaceRef.endsWith('sequence.xml')) {
+    if (!project.mediaSummary.webContentBundle?.name) {
+      console.log(
+        'CTAT w/sequence file requires webContentBundle option -- not handled'
+      );
+      return modelXml;
+    }
+
+    // ref was translated to web bundle URL. Get full path to file
+    const legacyRef = interfaceRef.substring(
+      interfaceRef.indexOf('/webcontent/')
+    );
+    const sequencePath = project.packageDirectory + '/content' + legacyRef;
+    console.log('Converting CTAT sequence file ' + sequencePath);
+
+    // translate asset refs in this file as we do for others.
+    const $ = DOM.read(sequencePath, {
+      xmlMode: true,
+      selfClosingTags: false,
+    });
+    fixSequenceFileRefs(sequencePath, $, project);
+
+    // to preserve /sequence.xml in path while leaving original file, we
+    //  put transformed version into /torus/ subdirectory of original location
+    const newPath = sequencePath.replace('sequence.xml', 'torus/sequence.xml');
+    const dirPath = newPath.substring(0, newPath.lastIndexOf('/'));
+    if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath);
+    fs.writeFileSync(newPath, $.html());
+
+    // return modelXml adjusted to reference variant file
+    const newRef = interfaceRef.replace('sequence.xml', 'torus/sequence.xml');
+    return modelXml.replace(interfaceRef, newRef);
+  }
+
+  // else no sequence file, just return unchanged
+  return modelXml;
+}
+
+function fixSequenceFileRefs(
+  sequencePath: string,
+  $: cheerio.Root,
+  project: ProjectSummary
+) {
+  const fixAttr = (item: cheerio.Element, attrName: string) => {
+    const value = $(item).attr(attrName);
+    if (value) {
+      const ref = { filePath: sequencePath, assetReference: value };
+      const url = getWebBundleUrl(
+        ref,
+        project.packageDirectory,
+        project.mediaSummary
+      );
+      if (url) {
+        const newRef = url.slice(url.lastIndexOf('media/') + 6);
+        $(item).attr(attrName, newRef);
+      }
+    }
+  };
+
+  $('Problems Problem').each((i: number, problem: any) => {
+    fixAttr(problem, 'problem_file');
+    fixAttr(problem, 'student_interface');
+  });
 }

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -10,12 +10,7 @@ import { guid } from 'src/utils/common';
 import * as XML from 'src/utils/xml';
 import { Maybe } from 'tsmonad';
 import { ProjectSummary } from 'src/project';
-import {
-  getWebBundleUrl,
-  MediaSummary,
-  resolve,
-  transformToFlatDirectory,
-} from 'src/media';
+import { getWebBundleUrl } from 'src/media';
 import * as DOM from 'src/utils/dom';
 import * as fs from 'fs';
 


### PR DESCRIPTION
Some CTAT superactivities of type` x-cmu-ctattutors` used in Genetics course have an `<interface>` element referencing a "sequence.xml" file defining a _set_ of problems, rather than an HTML file to be loaded. The use of sequence files cause problems for migrating these superactivities because the sequence files contain asset references that must be translated for use in torus. But these files are not resource files we would otherwise process in any way, rather just webcontent files.

Here we detect this case and handle by constructing a torus variant sequence file with translated URLs and adding it to the webcontent tree, adjusting the sequence file reference in the original superactivity descriptor to point to the torus variant. Because the CTAT superactivity code detects sequence file use by a special filename of "sequence.xml", we put the torus variant in a new `/torus/ `subdirectory of the webcontent folder where the original sequence file was.

This processing requires use of the -w webcontentBundle option to upload the tree of webcontent files.

Course using this:
https://svn.oli.cmu.edu/svn/content/genetics/branches/v_1_5/

Sample CTAT superactivity descriptor referencing a sequence file:
https://svn.oli.cmu.edu/svn/content/genetics/branches/v_1_5/content/x-cmu-ctattutors/PedigreeAnalysis_Activities/PedigreeAnalysisSeq_class.xml

The referenced sequence file:
https://svn.oli.cmu.edu/svn/content/genetics/branches/v_1_5/content/webcontent/PedigreeAnalysis/sequence.xml

