### PR TITLE
[BUG FIX] [MER-3636] handle manual graded multi-inputs

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -637,16 +637,20 @@ export function determineSubType(question: any): ItemTypes {
     Common.getChild(question, 'text') === undefined
   ) {
     const parts = Common.getChildren(question, 'part');
-
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
       const firstResponse = Common.getChild(part, 'response');
-      if (firstResponse !== undefined) {
-        question.children.push({
-          type: question.originalType,
-          id: firstResponse.input,
-        });
-      }
+      // try to find the input id for this part
+      const inputId =
+        firstResponse?.input ||
+        // some instructor-graded questions associate by targets attr on part
+        part.targets ||
+        part.id;
+      const input: any = { type: question.originalType, id: inputId };
+      // need to attach question grading flag if set
+      if (question.grading) input.grading = question.grading;
+
+      question.children.push(input);
     }
 
     return 'oli_multi_input';

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -319,7 +319,7 @@ export function getBranchingTarget(response: any) {
   return response.children[0]['xml:lang'];
 }
 
-function getGradingApproach(question: any) {
+export function getGradingApproach(question: any) {
   return question.grading === 'instructor' ? 'manual' : 'automatic';
 }
 
@@ -329,7 +329,10 @@ export function buildTextPart(id: string, question: any) {
   const skillrefs = getChildren(part, 'skillref');
   let legacyResponses = getChildren(part, 'response');
 
-  if (legacyResponses.length === 0) {
+  if (
+    legacyResponses.length === 0 &&
+    getGradingApproach(question) !== 'manual'
+  ) {
     console.log(`${id}: no response rules. Treating all responses as correct.`);
     legacyResponses = [{ match: '*', score: '1', children: [] }];
   }
@@ -402,7 +405,9 @@ export function ensureThree(hints?: any[]) {
 // returns JSON-form legacy response list to be converted to torus form
 export function adjustSubmitCompareResponses(origResponses: any[]) {
   // normally only has one wildcard response treated as correct
-  const correct = origResponses.find((r: any) => r.match === '*');
+  const correct =
+    origResponses.find((r: any) => r.match === '*') ||
+    origResponses.find((r: any) => r.score > 0);
   // change match to require input. .+ OK because torus trims whitespace
   correct.match = '/.+/';
   if (correct.score === undefined) correct.score = 1;


### PR DESCRIPTION
French course included some manually graded multi-input questions with text inputs. These were not being migrated correctly, not only because the grading type attribute was not processed at all for this question type, but also because questions used part definitions of the following form:

```
<part id="part1" targets="M2L1_pool2_q3_input1" score_out_of="3" />
 <part id="part2" targets="M2L1_pool2_q3_input2" score_out_of="4" />
 <part id="part3" targets="M2L1_pool2_q3_input3" score_out_of="3" />
```
in which parts are associated with inputRefs vis the "targets" attribute and contain no responses, a structure that also was never handled.

This PR adds support for migrating such questions correctly. It fills in default correct and incorrect responses to get past torus authoring UI requirements.

This also takes the opportunity cleans up some code in the relevant routines and add a bit of documentation on the somewhat involved processing being done.