### PR TITLE
[ENHANCEMENT] [BUG FIX[ don't quit on unsupported element so rest of course can migrate

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -87,8 +87,8 @@ export function addWarning(
 export function failIfPresent($: cheerio.Root, items: string[]) {
   items.forEach((e: string) => {
     $(e).each((_i: any, _item: any) => {
-      console.log(`unsupported element [${e}] detected, exiting`);
-      process.exit(1);
+      console.log(`unsupported element [${e}] detected, will not migrate`);
+      $(e).replaceWith(`<p>[Unmigrated legacy element: ${e}]</p>`);
     });
   });
 }


### PR DESCRIPTION
Change unsupported element handling to warn only rather than aborting migration so rest of course can migrate. Inserts brief note onto page in place of element. Will have to be handled post-migration.

Prompted by Anatomy and Physiology course which uses a few legacy multipanel activities which have to be replaced in torus though bulk of course migrates fine. 