### PR TITLE
[MER-3967] [ENHANCEMENT] Migrate instructor-only content blocks

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -14,6 +14,7 @@ import {
   processVariables,
   failIfPresent,
   failIfHasValue,
+  wrapContentInGroup,
 } from './common';
 import {
   findCustomTag,
@@ -903,11 +904,15 @@ export function processAssessmentModel(
       item.type === 'conclusion' ||
       item.type === 'content'
     ) {
-      const content: any = Object.assign(
-        {},
-        { type: 'content', id: guid() },
-        { children: item.children }
-      );
+      // allow for instructor-only blocks in summative content
+      const content1 = { type: 'content', id: guid(), children: item.children };
+      const content: any =
+        item.available === 'instructor_only'
+          ? Object.assign(wrapContentInGroup([content1]), {
+              audience: 'instructor',
+            })
+          : content1;
+
       if (pageId !== null) {
         content.page = pageId;
       }

--- a/src/resources/workbook.ts
+++ b/src/resources/workbook.ts
@@ -412,6 +412,15 @@ export function introduceStructuredContent(content: Element[]): Element[] {
       return [...u, refGroup];
     }
 
+    if (e.type === 'content' && e.available == 'instructor_only') {
+      const group = wrapContentInGroup([
+        { type: 'content', id: e.id || guid(), children: e.children },
+      ]);
+      (group as any).audience = 'instructor';
+
+      return [...u, group];
+    }
+
     if (isResourceGroup(e)) {
       const withStructuredContent = Object.assign({}, e, {
         children:


### PR DESCRIPTION
This migrates instructor-only content blocks on summative assessments and workbook pages. These are used extensively on quiz pages in CAHIMS course to include an instructor-only block giving link to the quiz solution. Processing also included for workbook pages because it is easy enough to support, though we have not encountered this case in a course.