### PR TITLE
[MER-3972] [BUG FIX] handle figures with captions

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -121,6 +121,9 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'definition>term', 'definition-term');
 
+  // torus figures don't have captions. strip to leave image w/caption & maybe title
+  DOM.eliminateLevel($, 'figure:has(caption)');
+
   // Torus figures require a title, so add one if missing. Do this
   // early to ensure gets any further title processing below
   $('figure:not(:has(title))').each((i: any, elem: any) => {


### PR DESCRIPTION
Torus figure elements have a title, but no caption. Legacy OLI figures may have both; this case was not being handled correctly. This PR handles figures with captions by migrating as plain images, w/any title prepended before it, just as if it was a titled image (which was also allowed in legacy). 