### PR TITLE
[MER-3973] [BUG FIX] strip composite activity w/only one child

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -121,6 +121,9 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'definition>term', 'definition-term');
 
+  // torus figures don't have captions. strip to leave image w/caption & maybe title
+  DOM.eliminateLevel($, 'figure:has(caption)');
+
   // Torus figures require a title, so add one if missing. Do this
   // early to ensure gets any further title processing below
   $('figure:not(:has(title))').each((i: any, elem: any) => {
@@ -302,7 +305,7 @@ export function standardContentManipulations($: any) {
   );
 
   // Strip composite-activity if only one child
-  DOM.eliminateLevel($, 'composite_activity:not(:has(> *:nth-child(2)))');
+  DOM.eliminateLevel($, 'composite_activity:has(> :only-child)');
 
   DOM.rename($, 'composite_activity', 'group');
 

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -121,9 +121,6 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'definition>term', 'definition-term');
 
-  // torus figures don't have captions. strip to leave image w/caption & maybe title
-  DOM.eliminateLevel($, 'figure:has(caption)');
-
   // Torus figures require a title, so add one if missing. Do this
   // early to ensure gets any further title processing below
   $('figure:not(:has(title))').each((i: any, elem: any) => {

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -301,6 +301,9 @@ export function standardContentManipulations($: any) {
     'innerpurpose'
   );
 
+  // Strip composite-activity if only one child
+  DOM.eliminateLevel($, 'composite_activity:not(:has(> *:nth-child(2)))');
+
   DOM.rename($, 'composite_activity', 'group');
 
   // Strip alternatives within feedback/explanation, won't work.


### PR DESCRIPTION
Composite activity containing a paged lbd in psychology course was causing problems for migration due to extra level of group nesting this gives rise to. However, turns out this was due to an entirely unnecessary use of the composite_activity tag to contain a single activity, evidently a style used by these course authors. Rather than rewrite source, this has migration tool strip redundant composite_activity tags wrapping a single child.