### PR TITLE
[ENHANCEMENT] [MER-4000] strip side-by-side materials containing activities

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -304,6 +304,12 @@ export function standardContentManipulations($: any) {
     'innerpurpose'
   );
 
+  // Strip side-by-side materials structure if contains inline activities
+  DOM.rename($, 'materials:has(wb\\:inline)', 'mtemp');
+  DOM.eliminateLevel($, 'mtemp>material:has(wb\\:inline)');
+  DOM.rename($, 'mtemp>material', 'p');
+  DOM.eliminateLevel($, 'mtemp');
+
   // Strip composite-activity if only one child
   DOM.eliminateLevel($, 'composite_activity:has(> :only-child)');
 


### PR DESCRIPTION
Anatomy & Physiology makes frequent use of side-by-side materials structure containing an image on one side and an inline assessment with one or more questions about the image on the other. While side-by-side materials can be migrated into torus tables, activities cannot be contained inside tables. This PR eliminates the side-by-side structure in this case so the course can be migrated into a structure the authors can see and perhaps edit. This will result in a sequential layout with the image above the questions. 