### PR TITLE
[ENHANCEMENT] [MER-4103] convert script-based image links to ordinary links

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -183,6 +183,13 @@ export function standardContentManipulations($: any) {
   DOM.rename($, 'image', 'img');
   DOM.rename($, 'link', 'a');
 
+  // change javascript:loadImage form of image link to direct image link
+  $('a[href^="javascript\\:loadImage"]').each((i: any, item: any) => {
+    const href = $(item).attr('href');
+    const imageRef = href.match(/javascript:loadImage\(['"](.+)['"]\)/)[1];
+    $(item).attr('href', imageRef);
+  });
+
   // Images "nested" inside paragraphs and links become inline images.
   // Block images are wrapped inside figures in Torus, so even if an
   // image in a legacy course is intended as a block semantically, with


### PR DESCRIPTION
Legacy Alvin Stats made use of script-based links to images of the form 
`<a href="javascript:loadImage('../webcontent/foo.gif')"> Click here </a> to see the graph`
where custom javascript was used to load and show the image in some way. 

These URLs were not processed by migration, so these migrated into broken links in the torus course. This PR converts them to ordinary links to the image file. The image URL is then translated appropriately. 

The behavior of these links will not be exactly the same as in legacy. But this allows them to be clicked to see the relevant image. 