### PR TITLE
[BUG FIX] [MER-4115] strip description elements from organization container items

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,9 @@ function validateArgs(options: CmdOptions) {
     if (options.inputDir) {
       // ensure absolute file system path, some path resolution steps require this
       options.inputDir = path.resolve(options.inputDir);
-      return [options.inputDir].every(fs.existsSync);
+      const ok = [options.inputDir].every(fs.existsSync);
+      if (!ok) console.log('inputDir not found: ' + options.inputDir);
+      return ok;
     }
   } else if (options.operation === 'summarize') {
     if (options.inputDir && options.outputDir) {

--- a/src/resources/organization.ts
+++ b/src/resources/organization.ts
@@ -26,12 +26,18 @@ function flattenOrganization($: any) {
   });
 }
 
+function removeContainerDescriptions($: any) {
+  $('unit > description').remove();
+  $('module > description').remove();
+  $('section > description').remove();
+}
+
 export class Organization extends Resource {
   restructure($: any): any {
     // failIfHasValue($, 'sequence', 'audience', 'instructor');
     failIfPresent($, ['include', 'unordered', 'supplement']);
 
-    $('description').remove();
+    removeContainerDescriptions($);
     DOM.flattenResourceRefs($);
     DOM.mergeTitles($);
     removeSequences($);

--- a/src/resources/organization.ts
+++ b/src/resources/organization.ts
@@ -31,6 +31,7 @@ export class Organization extends Resource {
     // failIfHasValue($, 'sequence', 'audience', 'instructor');
     failIfPresent($, ['include', 'unordered', 'supplement']);
 
+    $('description').remove();
     DOM.flattenResourceRefs($);
     DOM.mergeTitles($);
     removeSequences($);


### PR DESCRIPTION
Legacy organization items may include a `<description> `element containing descriptive text about the item. Passing these through for any item other than the root causes an error on ingestion as torus does not have a counterpart on its containers and ingestion is not coded to handle them This just removes any description elements on containers before further processing of the organization.

This PR also takes the opportunity to put in a more helpful error message for the case of a bad input directory on the command line. 