### PR TITLE
[BUG FIX] [MER-4149] handle ordering targeted feedback

### DIFF
--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -156,6 +156,13 @@ const updateResponseRules = (model: any) => {
   // translate rules in targeted feedback responses, checking for set-theoretic match rules
   model.authoring.targeted.forEach((assoc: any) => {
     const r = findResponse(model, getResponseId(assoc));
+    if (!r) {
+      console.log(
+        'cata/updateResponseRules: targeted response not found id=' +
+          getResponseId(assoc)
+      );
+      console.log(JSON.stringify(model.authoring.parts[0].responses, null, 2));
+    }
     const setOpMatch = r.rule.match(/^([!<=>]+)\{/);
     r.rule = setOpMatch
       ? convertSetRule(setOpMatch[1], getChoiceIds(assoc), allChoices)
@@ -186,7 +193,7 @@ export function buildCATAPart(question: any) {
         // legacy match pattern to be translated later on
         rule: cleanedMatch,
         legacyMatch: cleanedMatch,
-        namremoveSetOpse: r.name,
+        name: r.name, // used to filter AUTOGEN responses
         feedback: {
           id: guid(),
           content: Common.getFeedbackModel(r),
@@ -238,11 +245,11 @@ export function cata(question: any, from = 'multiple_choice') {
       incorrect: [],
     },
   };
-  const responseList = model.authoring.parts[0].responses;
 
   // Replaces any auto-generated incorrect responses with single catchall.
   Common.convertAutoGenResponses(model);
 
+  const responseList = model.authoring.parts[0].responses;
   let correctResponse = responseList.find(
     (r: any) => r.score !== undefined && r.score !== 0
   );

--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -156,13 +156,6 @@ const updateResponseRules = (model: any) => {
   // translate rules in targeted feedback responses, checking for set-theoretic match rules
   model.authoring.targeted.forEach((assoc: any) => {
     const r = findResponse(model, getResponseId(assoc));
-    if (!r) {
-      console.log(
-        'cata/updateResponseRules: targeted response not found id=' +
-          getResponseId(assoc)
-      );
-      console.log(JSON.stringify(model.authoring.parts[0].responses, null, 2));
-    }
     const setOpMatch = r.rule.match(/^([!<=>]+)\{/);
     r.rule = setOpMatch
       ? convertSetRule(setOpMatch[1], getChoiceIds(assoc), allChoices)

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -26,13 +26,13 @@ export function getDescendants(collection: any[], named: string): any[] {
 
 export function convertAutoGenResponses(model: any) {
   const autoGens = model.authoring.parts[0].responses.filter(
-    (r: any) => r.name !== undefined && r.name.indexOf('AUTOGEN') > -1
+    (r: any) => r.name !== undefined && r.name.includes('AUTOGEN')
   );
 
   if (autoGens.length > 0) {
     model.authoring.parts[0].responses =
       model.authoring.parts[0].responses.filter(
-        (r: any) => r.name === undefined || r.name.indexOf('AUTOGEN') === -1
+        (r: any) => r.name === undefined || !r.name.includes('AUTOGEN')
       );
 
     const catchAll = autoGens[0];

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -420,7 +420,7 @@ const escapeInput = (s: string) => s.replace(/[\\{}]/g, (i) => `\\${i}`);
 const unescapeInput = (s: string) =>
   s.replace(/\\[\\{}]/g, (i) => i.substring(1));
 
-const ruleArg = (r: string) =>
+export const ruleArg = (r: string) =>
   unescapeInput(r.substring(r.indexOf('{') + 1, r.lastIndexOf('}')));
 
 // legacy match value for text input is either special wildcard *


### PR DESCRIPTION
This fixes migration tool to fill in targeted feedback map for ordering questions. Failure to do this was the cause of https://eliterate.atlassian.net/browse/MER-4142. Also has it strip Echo "AUTOGEN" responses (set automatically generated identical responses for all possible wrong answers without substantive feedback) on these questions as is done for legacy CATA questions. This turned up typo and error breaking autogen processing even for CATA, so fixes that  as well.