### PR TITLE
[ENHANCEMENT][MER-4356] convert QTI exported quiz questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ npm start -- --operation convert --inputDir <course input dir> --outputDir ./out
 
 Before uploading media assets, you will need to configure AWS credentials and a bucket name.
 See detailed instructions in the [Wiki](https://github.com/Simon-Initiative/course-digest/wiki).
+
+The tool can also be used to [convert questions exported in QTI format](https://github.com/Simon-Initiative/course-digest/wiki/QTI-Conversion-mode).

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "command-line-args": "^5.1.1",
     "csv-writer": "^1.6.0",
     "dotenv": "^8.2.0",
+    "extract-zip": "^2.0.1",
     "filesize": "^10.0.7",
     "glob": "^7.1.6",
     "html-entities": "^2.3.3",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -436,7 +436,7 @@ export const checkActivity = (activity: Activity, page: string) => {
       xml.indexOf('<source>') + 8,
       xml.indexOf('</source>')
     );
-    console.log(`Script ${source}\t${page}`);
+    console.log(`Script ${source}\t${page}\t${activity.title}`);
   }
 };
 
@@ -457,7 +457,7 @@ function handleOnePlaceholder(
       wrapContentInSurveyOrGroup(
         derived.map((d) => {
           if (d.type === 'Activity') {
-            // checkActivity(d as Activity, page.title);
+            checkActivity(d as Activity, page.title);
             return {
               type: 'activity-reference',
               activity_id: d.id,
@@ -587,7 +587,10 @@ export function relativizeLegacyPaths(
   });
 }
 
-export function generatePoolTags(resources: TorusResource[]): TorusResource[] {
+export function generatePoolTags(
+  resources: TorusResource[],
+  prefix = 'Legacy Pool'
+): TorusResource[] {
   const tags: any = {};
 
   const items = resources.filter((r) => {
@@ -599,7 +602,7 @@ export function generatePoolTags(resources: TorusResource[]): TorusResource[] {
             legacyPath: null,
             legacyId: t,
             id: t,
-            title: `Legacy Pool: ${t}`,
+            title: `${prefix}: ${t}`,
             tags: [],
             unresolvedReferences: [],
             content: {},
@@ -777,10 +780,15 @@ async function wipeAndCreateOutput({ outputDirectory }: ProjectSummary) {
 
 function outputManifest(projectSummary: ProjectSummary) {
   const { packageDirectory, outputDirectory, svnRoot } = projectSummary;
-  const $ = DOM.read(`${packageDirectory}/content/package.xml`);
-  const title = $('package title').text();
-  const description = $('package description').text();
-
+  let title: string, description: string;
+  if (projectSummary.manifest) {
+    title = projectSummary.manifest.title;
+    description = projectSummary.manifest.description;
+  } else {
+    const $ = DOM.read(`${packageDirectory}/content/package.xml`);
+    title = $('package title').text();
+    description = $('package description').text();
+  }
   const manifest = {
     title,
     description,

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -457,7 +457,7 @@ function handleOnePlaceholder(
       wrapContentInSurveyOrGroup(
         derived.map((d) => {
           if (d.type === 'Activity') {
-            checkActivity(d as Activity, page.title);
+            // checkActivity(d as Activity, page.title);
             return {
               type: 'activity-reference',
               activity_id: d.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ import { filesize } from 'filesize';
 import * as archiver from 'archiver';
 import { Maybe } from 'tsmonad';
 import * as Merge from './merge';
+import { glob } from 'glob';
+import extract = require('extract-zip');
+import * as QTI from './qti';
+import { Activity } from './resources/resource';
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -47,14 +51,17 @@ const optionDefinitions = [
   { name: 'spreadsheetPath', type: String, alias: 's' },
   { name: 'svnRoot', type: String },
   { name: 'downloadRemote', type: Boolean, alias: 'r' },
-  { name: 'quiet', type: Boolean, alias: 'q' },
   { name: 'mergePathA', type: String, alias: 'a' },
   { name: 'mergePathB', type: String, alias: 'b' },
   { name: 'discussionsOn', type: Boolean, alias: 'd' },
+  // answers to convert prompts
+  { name: 'no', type: Boolean, alias: 'n' },
+  { name: 'yes', type: Boolean, alias: 'y' },
+  { name: 'zipOnly', type: Boolean, alias: 'z' },
 ];
 
 interface CmdOptions extends commandLineArgs.CommandLineOptions {
-  operation: 'summarize' | 'convert' | 'upload' | 'merge';
+  operation: 'summarize' | 'convert' | 'upload' | 'merge' | 'qti';
   mediaManifest: string;
   outputDir: string;
   inputDir: string;
@@ -62,11 +69,13 @@ interface CmdOptions extends commandLineArgs.CommandLineOptions {
   downloadRemote: boolean;
   specificOrg: string;
   mediaUrlPrefix: string;
-  quiet: boolean;
   mergePathA: string;
   mergePathB: string;
   discussionsOn: boolean;
   webContentBundle: string;
+  no?: boolean;
+  yes?: boolean;
+  zipOnly?: boolean;
 }
 
 interface ConvertedResults {
@@ -78,7 +87,7 @@ interface ConvertedResults {
 }
 
 function validateArgs(options: CmdOptions) {
-  if (options.operation === 'convert') {
+  if (options.operation === 'convert' || options.operation === 'qti') {
     if (options.mediaUrlPrefix === undefined) {
       options.mediaUrlPrefix = 'https://d2xvti2irp4c7t.cloudfront.net/media';
     } else {
@@ -111,14 +120,17 @@ function validateArgs(options: CmdOptions) {
     if (options.inputDir) {
       // ensure absolute file system path, some path resolution steps require this
       options.inputDir = path.resolve(options.inputDir);
-      const ok = [options.inputDir].every(fs.existsSync);
-      if (!ok) console.log('inputDir not found: ' + options.inputDir);
-      return ok;
+      if (![options.inputDir].every(fs.existsSync)) {
+        console.log('inputDir not found: ' + options.inputDir);
+        return false;
+      }
     }
+    // Just always zip when doing qti conversions
+    if (options.operation === 'qti') options.zipOnly = true;
+
+    return true;
   } else if (options.operation === 'summarize') {
-    if (options.inputDir && options.outputDir) {
-      return [options.inputDir].every(fs.existsSync);
-    }
+    return options.inputDir && options.outputDir;
   } else if (options.operation === 'upload') {
     return options.mediaManifest && fs.existsSync(options.mediaManifest);
   } else if (options.operation === 'merge') {
@@ -359,7 +371,8 @@ function suggestUploadAction(options: CmdOptions) {
   const manifest = readMediaManifest(options);
 
   return new Promise<string>((res) => {
-    if (options.quiet) res('n');
+    if (options.no || options.zipOnly) res('n');
+    else if (options.yes) res('y');
     else {
       const { mediaItems, mediaItemsSize } = manifest;
 
@@ -431,7 +444,8 @@ function zipAction(options: CmdOptions) {
 
 function suggestZipAction(options: CmdOptions) {
   return new Promise<string>((res) => {
-    if (options.quiet) res('n');
+    if (options.no) res('n');
+    else if (options.yes || options.zipOnly) res('y');
     else rl.question('Do you want to create a zip archive? [Y/n] ', res);
   }).then((answer: string) => {
     if (anyOf(answer || 'y', 'y', 'yes')) {
@@ -441,6 +455,53 @@ function suggestZipAction(options: CmdOptions) {
     console.log('Skipping zip archive.');
     return;
   });
+}
+
+// Handle input directory containing QTI package zips
+async function qtiAction(options: CmdOptions): Promise<any> {
+  const projectSummary = new ProjectSummary(
+    options.inputDir,
+    options.outputDir,
+    '',
+    {
+      mediaItems: {},
+      missing: [],
+      urlPrefix: options.mediaUrlPrefix,
+      downloadRemote: false,
+      flattenedNames: {},
+    }
+  );
+
+  const zips = glob.sync(`${options.inputDir}/*.zip`);
+
+  const zipProcessors = zips.map((file, i) => async () => {
+    const dir = file.replace('.zip', '');
+    if (!fs.existsSync(dir)) await extract(file, { dir });
+    return QTI.processQtiFolder(dir, projectSummary);
+  });
+
+  const activities: Activity[] = await executeSerially(zipProcessors);
+  console.log(`Got ${activities.length} activities`);
+
+  // have to generate Tags for the activities
+  const resources = Convert.generatePoolTags(activities, 'QTI');
+
+  // include empty hierarchy
+  const hierarchy: Resources.Hierarchy = {
+    type: 'Hierarchy',
+    id: '',
+    legacyPath: '',
+    legacyId: '',
+    title: '',
+    tags: [],
+    unresolvedReferences: [],
+    children: [],
+    warnings: [],
+  };
+  // create some sort of manifest
+  projectSummary.manifest = { title: 'QTI Import', description: '' };
+
+  await Convert.output(projectSummary, hierarchy, resources, []);
 }
 
 function helpAction() {
@@ -488,6 +549,10 @@ function main() {
         options.outputDir
       );
       exit();
+    } else if (options.operation === 'qti') {
+      qtiAction(options)
+        .then(() => suggestZipAction(options))
+        .then(exit);
     } else {
       helpAction();
       exit();

--- a/src/index.ts
+++ b/src/index.ts
@@ -474,7 +474,7 @@ async function qtiAction(options: CmdOptions): Promise<any> {
 
   const zips = glob.sync(`${options.inputDir}/*.zip`);
 
-  const zipProcessors = zips.map((file, i) => async () => {
+  const zipProcessors = zips.map((file) => async () => {
     const dir = file.replace('.zip', '');
     if (!fs.existsSync(dir)) await extract(file, { dir });
     return QTI.processQtiFolder(dir, projectSummary);

--- a/src/project.ts
+++ b/src/project.ts
@@ -16,6 +16,8 @@ export class ProjectSummary {
   svnRoot: string;
   mediaSummary: MediaSummary;
   alternativeGroups: Record<string, Set<string>>;
+  // for QTI conversion
+  manifest?: { title: string; description: string };
 
   constructor(
     packageDirectory: string,

--- a/src/qti.ts
+++ b/src/qti.ts
@@ -1,0 +1,631 @@
+import * as Cheerio from 'cheerio';
+import { ProjectSummary } from './project';
+import * as Common from './resources/questions/common';
+import {
+  eqRule,
+  matchListRule,
+  matchRule,
+  setDifference,
+} from './resources/questions/rules';
+import { executeSerially, guid, replaceAll, toPlainText } from './utils/common';
+import * as DOM from './utils/dom';
+import * as fs from 'fs';
+import { standardContentManipulations } from './resources/common';
+import * as XML from 'src/utils/xml';
+import { Activity } from './resources/resource';
+import { decode } from 'html-entities';
+import { updateInputRefs } from './resources/questions/multi';
+
+// Convert QTI 1.2 format archives as exported from Canvas or Blackboard into archive of banked questions
+// Blackboard QTI exports include non-standard Blackboard extensions and has slight differences.
+// Code attempts to handle both where there are differences.
+
+// Note: because we rely the existing Promise-valued routine XML.toJSON at leaves of call tree to convert bits of content
+// (stem, choices, feedback) where needed to our content model, essentially every function becomes async. However,
+// serial processing it is very desireable to ensure trace and debugging messages come out in an intelligible
+// order. Therefore care is taken to ensure serial processing via executeSerially, though this adds some complexity.
+export function processQtiFolder(
+  dir: string,
+  _projectSummary: ProjectSummary
+): Promise<Activity[]> {
+  return new Promise((resolve, _reject) => {
+    console.log('Processing QTI package ' + dir);
+
+    // load manifest
+    const manifest = dir + '/' + 'imsmanifest.xml';
+    if (!fs.existsSync(manifest)) {
+      console.log(`imsmanifest.xml not found in ${dir}`);
+      resolve([]);
+    }
+    const $ = DOM.read(manifest);
+
+    // process each resource element in turn
+    const fileProcessors = $('resource')
+      .map(
+        (i: number, resource: any) => () =>
+          processManifestResource($, resource, dir)
+      )
+      .get();
+
+    // result is concatenated list of activities from each resource file
+    resolve(executeSerially(fileProcessors));
+  });
+}
+
+// resolves to list of activity resources, [] if none
+async function processManifestResource(
+  $: cheerio.Root,
+  resource: cheerio.TagElement,
+  dir: string
+): Promise<Activity[]> {
+  return new Promise((resolve, _reject) => {
+    //  Blackboard has file path in bb:file attr; Canvas in <file href="..."" /> child
+    const file =
+      $(resource).attr('bb:file') || $(resource).find('file').attr('href');
+    if (!file) resolve([]);
+
+    // Detect files we want by sniffing root element
+    const doc = DOM.read(`${dir}/${file}`);
+    const rootTag = doc(':root').prop('tagName').toLowerCase();
+    if (rootTag !== 'questestinterop') resolve([]);
+
+    // else a questtestinterop file
+    const title = doc('assessment').attr('title') || file;
+
+    const itemProcessors = doc('item')
+      .map((i, item) => () => processQtiItem(doc, item, title!, i))
+      .get();
+    resolve(executeSerially(itemProcessors));
+  });
+}
+
+async function processQtiItem(
+  $: cheerio.Root,
+  item: any,
+  title: string,
+  i: number
+) {
+  // get value from named item metadata field
+  const getFieldValue = (fieldlabel: string) =>
+    $(item)
+      .find(
+        `qtimetadatafield:has(fieldlabel:contains("${fieldlabel}")) fieldentry`
+      )
+      .first()
+      .text();
+
+  // QTI standard does not specify question type names, but it is convenient to have them. Canvas uses the QTI-standard
+  // qtimetadata extension mechanism for "external vocabulary" to include a "question_type" field. Blackboard includes
+  // its question type identifiers in a custom bbmd_questiontype field in its own custom metadata section.
+  // Lower-case types below are from Canvas; mixed-case are Blackboard's
+  const bbType = $(item).find('bbmd_questiontype').first();
+  const type =
+    $(bbType).length > 0 ? $(bbType).text() : getFieldValue('question_type');
+
+  var q, subType: any;
+  switch (type) {
+    case 'multiple_choice_question':
+    case 'true_false_question':
+    case 'Multiple Choice':
+      subType = 'oli_multiple_choice';
+      q = await build_multiple_choice($, item);
+      break;
+    case 'multiple_answers_question':
+    case 'Multiple Answer':
+      subType = 'oli_check_all_that_apply';
+      q = await build_cata($, item);
+      break;
+    case 'multiple_dropdowns_question':
+    case 'Jumbled Sentence':
+      subType = 'oli_multi_input';
+      q = await build_multi_dropdown($, item);
+      break;
+    case 'numerical_question':
+    case 'Numeric':
+      subType = 'oli_short_answer';
+      q = await build_short_answer($, item, 'numeric');
+      break;
+    case 'calculated_question':
+    case 'Calculated':
+      subType = 'oli_short_answer';
+      q = await build_calculated($, item);
+      break;
+    default:
+      console.log('Unsupported question type: ' + type);
+      return [];
+  }
+
+  console.log(`Question type ${type}`);
+  return {
+    type: 'Activity',
+    subType,
+    id: guid(),
+    title: `${title}-q${i}`,
+    content: q,
+    scope: 'banked',
+    tags: [title],
+    unresolvedReferences: [],
+    objectives: [],
+    legacyPath: '',
+    legacyId: '',
+    warnings: [],
+  };
+}
+
+async function build_multiple_choice($: cheerio.Root, item: any) {
+  return {
+    stem: await getStem($, item),
+    choices: await getChoices($, item),
+    authoring: {
+      version: 2,
+      parts: [mcq_part($, item)],
+      transformations: getShuffle($, item)
+        ? [Common.shuffleTransformation()]
+        : [],
+      targeted: [],
+      previewText: '',
+    },
+  };
+}
+
+function mcq_part($: cheerio.Root, item: any, response_id: string = '') {
+  const correctResp = findCorrectResp($, item, response_id);
+  const correctId = $(correctResp).find('varequal').first().text();
+  const correctResponse = {
+    id: guid(),
+    score: 1,
+    rule: matchRule(correctId),
+    feedback: {
+      id: guid(),
+      content: Common.buildContentModelFromText('Correct'),
+    },
+  };
+  return {
+    id: response_id === '' ? '1' : response_id,
+    responses: [correctResponse, Common.makeCatchAllResponse()],
+    hints: Common.ensureThree(),
+    scoringStrategy: 'average',
+  };
+}
+
+function getShuffle($: cheerio.Root, item: any, respident: string = '') {
+  // use optional respident to qualify selection on multi-part questions
+  const choiceSelector =
+    respident === '' ? 'render_choice' : `response_lid[ident="{respident}"]`;
+  return $(item).find(choiceSelector).attr('shuffle') === 'Yes';
+}
+
+function findCorrectResp($: cheerio.Root, item: any, respident: string = '') {
+  // use optional respident to qualify selection on multi-part questions
+  const varequalSelector =
+    respident === '' ? 'varequal' : `varequal[respident="${respident}"]`;
+  let correct: any;
+  $(item)
+    .find(`respcondition:has(${varequalSelector})`)
+    .each((i: number, resp: any) => {
+      if (
+        $(resp).attr('title') === 'correct' ||
+        $(resp).find('setvar:contains("SCORE.max")').length == 1 ||
+        // Canvas seems to always set correct score of 100, presumably percentage
+        $(resp).find('setvar:contains("100")').length === 1
+        // Otherwise should check for max declared value of outcome variable
+      )
+        correct = resp;
+    });
+  return correct;
+}
+
+async function build_cata($: cheerio.Root, item: any) {
+  const choices = await getChoices($, item);
+  const [part, correct] = cata_part($, item, choices);
+  return {
+    stem: await getStem($, item),
+    choices,
+    authoring: {
+      version: 2,
+      parts: [part],
+      correct,
+      transformations: getShuffle($, item)
+        ? [Common.shuffleTransformation()]
+        : [],
+      previewText: '',
+      targeted: [],
+    },
+  };
+}
+
+function cata_part($: cheerio.Root, item: any, choices: any[]) {
+  const correctResp = findCorrectResp($, item);
+  const allIds = choices.map((choice: any) => choice.id);
+  const incorrectIds = $(correctResp)
+    .find('not>varequal')
+    .map((i: number, vareq: any) => $(vareq).text())
+    .get();
+  const correctIds = setDifference(allIds, incorrectIds);
+  const correctResponse = {
+    id: guid(),
+    score: 1,
+    rule: matchListRule(allIds, correctIds),
+    feedback: {
+      id: guid(),
+      content: Common.buildContentModelFromText('Correct'),
+    },
+  };
+  // return part plus correct map
+  return [
+    {
+      id: '1',
+      responses: [correctResponse, Common.makeCatchAllResponse()],
+      hints: Common.ensureThree(),
+      scoringStrategy: 'average',
+    },
+    // torus model uses to map from correct ID set to response id
+    [correctIds, correctResponse.id],
+  ];
+}
+
+async function build_multi_dropdown($: cheerio.Root, item: any) {
+  // following collect choices and inputs for all parts:
+  const choices: any[] = [];
+  const inputs: any[] = [];
+  const parts: any[] = [];
+  const transformations: any[] = [];
+
+  const stem = await getStem($, item, 'inputs');
+
+  // In QTI, each input to fill in is a "response", corresponding to a torus part.
+  // When answer type is a logical id ("lid") as for choices, QTI response is specified
+  // by a response_lid element with id in "ident" attribute. Result processing rules are
+  // linked to part by matching "respid" attribute = response ident in the varequal element.
+  // Although this is NOT part of QTI 1.2 standard, Canvas,Blackboard apparently indicate
+  // dropdown locationsby associated input item id such as a, b embedded in stem as [a], [b].
+  // Blackboard exports just use the input ids a and b as the response ident. Canvas uses
+  // distinct response idents and includes the linked input id as piece of mattext content
+  // within the response_lid element. Canvase also seems to generate response idents of form
+  // response_a, response_b. We rely on latter convention to match responses to input ids.
+  const responses = $(item).find('response_lid').get();
+  for (let response of responses) {
+    const response_id = $(response).attr('ident') || 'missing_response_id';
+    const response_input_id = response_id?.includes('_')
+      ? response_id.split('_')[1]
+      : response_id;
+
+    // get choices within current response,  ignoring the "choose one" choice
+    // for dropdown that gets included
+    const choicesTemp = await getChoices($, response);
+    const responseChoices = choicesTemp.filter(
+      (c: any) => toPlainText(c.content) !== 'choose one'
+    );
+
+    choices.push(...responseChoices);
+
+    inputs.push({
+      id: response_input_id,
+      inputType: 'dropdown',
+      choiceIds: responseChoices.map((c: any) => c.id),
+      partId: response_id,
+      // could estimate size from max choice text length
+    });
+
+    parts.push(mcq_part($, item, response_id));
+
+    if (getShuffle($, item, response_id))
+      transformations.push(Common.shufflePartTransformation(response_id));
+  }
+
+  return {
+    stem,
+    choices,
+    inputs,
+    submitPerPart: true,
+    authoring: {
+      version: 2,
+      parts,
+      transformations,
+      previewText: '',
+      targeted: [],
+    },
+  };
+}
+
+async function build_short_answer(
+  $: cheerio.Root,
+  item: any,
+  inputType: 'numeric' | 'text'
+) {
+  return {
+    stem: await getStem($, item),
+    inputType,
+    authoring: {
+      version: 2,
+      parts: [short_answer_part($, item, inputType)],
+      transformations: [],
+      previewText: '',
+      targeted: [],
+    },
+  };
+}
+
+function short_answer_part($: cheerio.Root, item: any, inputType: string) {
+  const correctResp = findCorrectResp($, item);
+  let rule = eqRule('1'); // dummy
+  if (inputType === 'numeric') {
+    const varequal = $(correctResp).find('varequal')[0];
+    if (varequal) {
+      rule = eqRule($(varequal).text());
+    } else {
+      const varlb = $(correctResp).find('varlte, varlt')[0];
+      const varub = $(correctResp).find('vargte, vargt')[0];
+      if (varlb && varub) {
+        // both upper and lower bound => range rule
+        // console.log('found upper and lower bound rules');
+        // but have seen this special case in canvas export:
+        if ($(varlb).text() === $(varub).text()) {
+          rule = eqRule($(varlb).text());
+        } else {
+          const lbchar = $(varlb).prop('tagName') === 'varlt' ? '(' : '[';
+          const rbchar = $(varub).prop('tagName') === 'vargt' ? ')' : ']';
+          rule = eqRule(
+            lbchar + $(varlb).text() + ',' + $(varub).text() + rbchar
+          );
+        }
+      }
+      // else could be pure lt or gt rule, rare in practice
+    }
+  }
+  // TODO: else handle string rule
+  const correctResponse = {
+    id: guid(),
+    score: 1,
+    rule,
+    feedback: {
+      id: guid(),
+      content: Common.buildContentModelFromText('Correct'),
+    },
+  };
+  return {
+    id: '1',
+    responses: [correctResponse, Common.makeCatchAllResponse()],
+    hints: Common.ensureThree(),
+    scoringStrategy: 'average',
+  };
+}
+
+async function build_calculated($: cheerio.Root, item: any) {
+  // build up Javascript variable code for transform
+  const codelines = [];
+  let scale;
+  $(item)
+    .find('vars>var')
+    .each((i: number, elem: any) => {
+      const name = $(elem).attr('name');
+      const min = $(elem).find('min').first().text();
+      const max = $(elem).find('max').first().text();
+      // number of decimal points
+      scale = $(elem).attr('scale') || '0';
+      codelines.push(`const ${name} = OLI.random(${min}, ${max}, ${scale});`);
+    });
+  const formulaEncoded = $(item).find('formula').first().text();
+  const formulaMathML = decode(replaceAll(formulaEncoded, '&amp;', '&'), {
+    level: 'html5',
+  });
+  const formulaJavascript = MathMlToJavascript(formulaMathML);
+  // hard to know where to get decimal places required in answer, does not seem explicit.
+  // Try to sniff from first sample answer.
+  const sampleAnswer = $(item).find('var_set>answer').first().text();
+  const sampleDecimalPart = sampleAnswer.split('.')[1];
+  const answerDecimals = sampleDecimalPart ? sampleDecimalPart.length : 0;
+  codelines.push(
+    `const answer = (${formulaJavascript}).toFixed(${answerDecimals});`
+  );
+  let ruleArg = '@@answer@@';
+
+  // If includes a percent tolerance, define vars for bounds
+  // Unclear how to interpret other types of tolerance -- this is not qti standard
+  const tolerance = $(item).find('answer_tolerance[type=percent]')[0];
+  if (tolerance) {
+    const percent = $(tolerance).text();
+    codelines.push(`const ansLow = (1 - 0.01*${percent})*answer`);
+    codelines.push(`const ansHigh = (1 + 0.01*${percent})*answer`);
+    ruleArg = '[@@ansLow@@,@@ansHigh@@]';
+  }
+
+  // list exported vars
+  const allVars = codelines.map((line: string) => line.split(' ')[1]);
+  codelines.push(`module.exports = {`);
+  allVars.forEach((v) => codelines.push(`   ${v},`));
+  codelines.push(`};`);
+
+  const expression = codelines.join('\n');
+  // console.log('expression:\n' + expression);
+
+  const transform = {
+    operation: 'variable_substitution',
+    id: guid(),
+    firstAttemptOnly: false,
+    data: [
+      {
+        type: 'variable',
+        id: guid(),
+        name: 'module',
+        variable: 'module',
+        expression,
+      },
+    ],
+  };
+
+  const correctResponse = {
+    id: guid(),
+    score: 1,
+    rule: eqRule(ruleArg),
+    feedback: {
+      id: guid(),
+      content: Common.buildContentModelFromText('Correct'),
+    },
+  };
+  const part = {
+    id: '1',
+    responses: [correctResponse, Common.makeCatchAllResponse()],
+    hints: Common.ensureThree(),
+    scoringStrategy: 'average',
+  };
+
+  return {
+    stem: await getStem($, item, 'variables'),
+    inputType: 'numeric',
+    authoring: {
+      version: 2,
+      parts: [part],
+      transformations: [transform],
+      previewText: '',
+      targeted: [],
+    },
+  };
+}
+
+function MathMlToJavascript(mathML: string) {
+  /*
+  // rudimentary start: strip tags, adjust special chars and hope
+  const plainText = mathML.replace(/(<([^>]+)>)/gi, '');
+  const expr = plainText.replace('÷', '/').replace('×', '*');
+  */
+  const $ = Cheerio.load(mathML, { xmlMode: true });
+
+  function translate(elem: cheerio.Element): string {
+    let result = '';
+
+    const tagName = (elem as cheerio.TagElement).tagName;
+
+    if ($(elem).children().length === 0) {
+      // leaf node: could be mn (number), mi (identifier), mo (operator)
+      result = $(elem).text();
+      if (tagName === 'mo') result = result.replace('÷', '/').replace('×', '*');
+    } else if (tagName === 'mfrac') {
+      // Fraction
+      const numExpr = translate($(elem).children()[0]);
+      const denomExpr = translate($(elem).children()[1]);
+      result = `(${numExpr})/(${denomExpr})`;
+    } else if (tagName === 'msup') {
+      // Superscript (power)
+      const baseExpr = translate($(elem).children()[0]);
+      const expExpr = translate($(elem).children()[1]);
+      result = `Math.pow(${baseExpr}, ${expExpr})`;
+    } else if (tagName === 'mroot') {
+      // Root with index
+      const argExpr = translate($(elem).children()[0]);
+      const rootExpr = translate($(elem).children()[1]);
+      result = `Math.pow(${argExpr}, 1/(${rootExpr}))`;
+    } else {
+      // any other node with children (includes math root): concat child results
+      result = $(elem)
+        .children()
+        .get()
+        .map((child) => translate(child))
+        .join('');
+    }
+
+    if (tagName === 'msqrt') {
+      // Square root
+      result = `Math.sqrt(${result})`;
+    } else if (tagName === 'mrow') {
+      // Grouping
+      result = `(${result})`;
+    }
+
+    return result;
+  }
+
+  const expression = translate($('math')[0]);
+  const expr = expression.replace(/\s+/g, ' ').trim();
+  // console.log('MathML to Javascript: ', mathML, '\n', expr);
+  return expr;
+}
+
+async function getChoices($: cheerio.Root, item: any) {
+  const choiceGetters = $(item)
+    .find('render_choice response_label')
+    .map((i: number, elem: any) => async () => {
+      const content = await getContent($, elem);
+      return {
+        id: $(elem).attr('ident'),
+        content: Common.ensureParagraphs(content as any[]),
+      };
+    })
+    .get();
+
+  return await executeSerially(choiceGetters);
+}
+
+async function getStem($: cheerio.Root, item: any, replace: string = '') {
+  const presentation = $(item).find('presentation').first();
+  let content = await getContent($, presentation, replace);
+  // have to fix up input refs post conversion
+  if (replace === 'inputs') content = updateInputRefs(content, {});
+
+  return { content: Common.ensureParagraphs(content as any[]) };
+}
+
+async function getContent($: cheerio.Root, elem: any, replace: string = '') {
+  // Blackboard may use mat_formattedtext extension
+  const mattext = $(elem).find('mattext, mat_formattedtext').first();
+  const rawtext = $(mattext).text();
+
+  let text = rawtext;
+  if (replace === 'variables')
+    text = text.replace(/\[/g, '@@').replace(/\]/g, '@@');
+  else if (replace === 'inputs') {
+    // translate to unrestructured legacy input_ref tag form
+    text = text.replace('[', '<input_ref input="').replace(']', '"/>');
+  }
+
+  if ($(mattext).attr('texttype') === 'text/plain')
+    return Common.buildContentModelFromText(text);
+
+  // Else HTML as XML-encoded text content:  &lt;, &gt; around tags,
+  // other ampersand-escaped items as e.g. &amp;nbsp;
+  const html = decode(replaceAll(text, '&amp;', '&'), { level: 'html5' });
+  // console.log('html: ' + html);
+
+  /*
+  // just strips any html tags. Leaves white space around tags
+  const plainText = html.replace(/(<([^>]+)>)/gi, '');
+  // console.log('plainText= ' + plainText);
+  return Common.buildContentModelFromText(plainText);
+*/
+
+  return await htmlToContentModel(html);
+}
+
+async function htmlToContentModel(html: string) {
+  // parse fragment as xml doc
+  const $ = Cheerio.load(`<html><body>${html}</body><html>`, { xmlMode: true });
+
+  // restructure as we do for legacy XML content. Overkill, but adjusts some elements we want:
+  // unwrapped mathML to formula-inline, inline styles like sup to em tag form handled by toJSON
+  standardContentManipulations($);
+  // do some custom restructuring for our html.
+  // Canvas output wraps content in div, not p
+  DOM.eliminateLevel($, 'div:has(>p)');
+  DOM.rename($, 'div', 'p');
+  // Output can wrap text in junk spans with app-specific classes, e.g. <span class="prompt">
+  $('span').each(function () {
+    $(this).replaceWith($(this).text());
+  });
+
+  const xml = $.html();
+  // console.log('xml after restructure:' + xml);
+  const docJSON: any = await XML.toJSON(xml, {} as ProjectSummary, {
+    p: true,
+    em: true,
+    li: true,
+    td: true,
+    th: true,
+    dt: true,
+    dd: true,
+  });
+
+  // desired content model = list of content elements in doc body
+  const content = Common.getDescendants(docJSON.children, 'body')[0].children;
+  // console.log(`json: ${JSON.stringify(content, null, 2)}\n`);
+  return content;
+}

--- a/src/qti.ts
+++ b/src/qti.ts
@@ -180,7 +180,7 @@ async function build_multiple_choice($: cheerio.Root, item: any) {
 
 function mcq_part($: cheerio.Root, item: any, response_id: string = '') {
   const correctResp = findCorrectRespCondition($, item, response_id);
-  const correctId = $(correctResp).find('varequal').first().text();
+  const correctId = $(correctResp).find('varequal').text().trim();
   const correctResponse = {
     id: guid(),
     score: 1,
@@ -257,7 +257,7 @@ function cata_part($: cheerio.Root, item: any, choices: any[]) {
   const allIds = choices.map((choice: any) => choice.id);
   const incorrectIds = $(correctResp)
     .find('not>varequal')
-    .map((i: number, vareq: any) => $(vareq).text())
+    .map((i: number, vareq: any) => $(vareq).text().trim())
     .get();
   const correctIds = setDifference(allIds, incorrectIds);
   const correctResponse = {

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -373,6 +373,9 @@ export function standardContentManipulations($: any) {
 
   DOM.rename($, 'li formula', 'formula_inline');
   DOM.rename($, 'li callback', 'callback_inline');
+
+  // Torus input_ref's use id attribute
+  DOM.renameAttribute($, 'input_ref', 'input', 'id');
 }
 
 function handleCommandButtons($: any) {
@@ -719,6 +722,7 @@ export function handleFormulaMathML($: any) {
   $('math').wrap(formula_inline);
   $('formula_inline_temp').each((i: any, item: any) => {
     item.tagName = 'formula_inline';
+    const mathML = getFirstMathML($, item);
     $(item).attr('src', getFirstMathML($, item));
     item.children = [];
   });

--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -722,7 +722,6 @@ export function handleFormulaMathML($: any) {
   $('math').wrap(formula_inline);
   $('formula_inline_temp').each((i: any, item: any) => {
     item.tagName = 'formula_inline';
-    const mathML = getFirstMathML($, item);
     $(item).attr('src', getFirstMathML($, item));
     item.children = [];
   });

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -149,7 +149,7 @@ export function removeRedundantInputRefs(
 ) {
   if (!Array.isArray(children)) return children;
   return children
-    .filter((c) => !(c.type === 'input_ref' && c.input === redundantInputId))
+    .filter((c) => !(c.type === 'input_ref' && c.id === redundantInputId))
     .map((child) => {
       if (child.children) {
         child.children = removeRedundantInputRefs(

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -90,11 +90,11 @@ export function buildMulti(
   };
 }
 
-function updateInputRefs(model: any, foundInputs: any): any {
+export function updateInputRefs(model: any, foundInputs: any): any {
   if (model.type === 'input_ref') {
-    foundInputs[model.input] = true;
+    foundInputs[model.id] = true;
+    // add empty text child, required by slate editor on block elements
     return Object.assign({}, model, {
-      id: model.input,
       children: [{ text: '' }],
     });
   }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -14,7 +14,8 @@ export function replaceAll(s: string, t: string, w: string) {
 
 // Take an array of functions that return promises and
 // execute them serially, resolving an array of their
-// resolutions
+// resolutions. Note: results formed by successive concatenation, so if
+// individual function result is array, its contents are spliced in
 export const executeSerially = (funcs: any) =>
   funcs.reduce(
     (promise: any, func: any) =>

--- a/test/qti-convert-test.ts
+++ b/test/qti-convert-test.ts
@@ -1,0 +1,70 @@
+import { ProjectSummary } from 'src/project';
+import { processQtiFolder } from 'src/qti';
+import { getDescendants } from 'src/resources/questions/common';
+import { toPlainText } from 'src/utils/common';
+
+// Test conversion of QTI package containing supported question types
+
+it('should convert sample QTI folder to set of activities', async () => {
+  // Test on already-unzipped QTI package folder containing one sample
+  // assessment edited to contain one of each supported question type
+  const activities = await processQtiFolder(
+    './test/qti/Mod2ReadingQuiz',
+    {} as ProjectSummary
+  );
+
+  expect(activities.length).toEqual(5);
+
+  // Spot check activities and their models
+  const [act1, act2, act3, act4, act5] = activities;
+  const [m1, m2, m3, m4, m5] = activities.map((a) => a.content as any);
+
+  // Multiple Choice
+  expect(act1.subType).toEqual('oli_multiple_choice');
+  expect(toPlainText(m1.stem.content)).toEqual('1.000 mm = ________');
+  expect(m1.choices.length).toEqual(4);
+  const correctId = m1.choices[1].id;
+  expect(m1.authoring.parts[0].responses.length).toEqual(2);
+  const correctResponse1 = m1.authoring.parts[0].responses[0];
+  expect(correctResponse1.rule).toEqual(`input like {${correctId}}`);
+  expect(correctResponse1.score).toEqual(1);
+
+  // CATA
+  expect(act2.subType).toEqual('oli_check_all_that_apply');
+  const choices = m2.choices.map((c: any) => c.id);
+  expect(choices.length).toEqual(4);
+  //     check involved rule for CATA correctness
+  const cataRule = m2.authoring.parts[0].responses[0].rule;
+  expect(cataRule).toEqual(
+    `(!(input like {${choices[2]}})) && ((!(input like {${choices[1]}})) && (input like {${choices[3]}} && (input like {${choices[0]}})))`
+  );
+
+  // short answer numeric with dynamic variables
+  expect(act3.subType).toEqual('oli_short_answer');
+  expect(toPlainText(m3.stem.content)).toContain('@@x@@');
+  expect(toPlainText(m3.stem.content)).toContain('@@y@@');
+  expect(m3.authoring.transformations.length).toEqual(1);
+  expect(m3.authoring.transformations[0].operation).toEqual(
+    'variable_substitution'
+  );
+  expect(m3.authoring.transformations[0].data[0].expression).toEqual(
+    expect.stringContaining('const x = OLI.random(30.0, 40.0, 1);')
+  );
+  expect(m3.authoring.parts[0].responses[0].rule).toEqual(
+    'input = {@@answer@@}'
+  );
+
+  // dropdown question
+  expect(act4.subType).toEqual('oli_multi_input');
+  //    make sure we defined input and inserted inputref
+  expect(m4.inputs.length).toEqual(1);
+  expect(m4.inputs[0].id).toEqual('a');
+  const inputRefs = getDescendants(m4.stem.content, 'input_ref');
+  expect(inputRefs.length).toEqual(1);
+  expect(inputRefs[0].id).toEqual('a');
+
+  // short answer numeric
+  expect(act5.subType).toEqual('oli_short_answer');
+  //   handles special case: answer with equal upper and lower bounds
+  expect(m5.authoring.parts[0].responses[0].rule).toEqual('input = {500.0}');
+});

--- a/test/qti/Mod2ReadingQuiz/g3e9bef852d702d51e2f7d73269ed2023/assessment_meta.xml
+++ b/test/qti/Mod2ReadingQuiz/g3e9bef852d702d51e2f7d73269ed2023/assessment_meta.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz identifier="g3e9bef852d702d51e2f7d73269ed2023" xmlns="http://canvas.instructure.com/xsd/cccv1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
+  <title>Module 2 Reading Quiz</title>
+  <description></description>
+  <shuffle_answers>false</shuffle_answers>
+  <scoring_policy>keep_highest</scoring_policy>
+  <hide_results></hide_results>
+  <quiz_type>assignment</quiz_type>
+  <points_possible>62.0</points_possible>
+  <require_lockdown_browser>false</require_lockdown_browser>
+  <require_lockdown_browser_for_results>false</require_lockdown_browser_for_results>
+  <require_lockdown_browser_monitor>false</require_lockdown_browser_monitor>
+  <lockdown_browser_monitor_data/>
+  <show_correct_answers>true</show_correct_answers>
+  <anonymous_submissions>false</anonymous_submissions>
+  <could_be_locked>false</could_be_locked>
+  <disable_timer_autosubmission>false</disable_timer_autosubmission>
+  <allowed_attempts>1</allowed_attempts>
+  <one_question_at_a_time>false</one_question_at_a_time>
+  <cant_go_back>false</cant_go_back>
+  <available>false</available>
+  <one_time_results>false</one_time_results>
+  <show_correct_answers_last_attempt>false</show_correct_answers_last_attempt>
+  <only_visible_to_overrides>false</only_visible_to_overrides>
+  <module_locked>false</module_locked>
+  <assignment identifier="gb9ccde2a0f510860793776aaab832334">
+    <title>Module 2 Reading Quiz</title>
+    <due_at/>
+    <lock_at/>
+    <unlock_at/>
+    <module_locked>false</module_locked>
+    <workflow_state>unpublished</workflow_state>
+    <assignment_overrides>
+    </assignment_overrides>
+    <quiz_identifierref>g3e9bef852d702d51e2f7d73269ed2023</quiz_identifierref>
+    <allowed_extensions></allowed_extensions>
+    <has_group_category>false</has_group_category>
+    <points_possible>62.0</points_possible>
+    <grading_type>points</grading_type>
+    <all_day>false</all_day>
+    <submission_types>online_quiz</submission_types>
+    <position>14</position>
+    <turnitin_enabled>false</turnitin_enabled>
+    <vericite_enabled>false</vericite_enabled>
+    <peer_review_count>0</peer_review_count>
+    <peer_reviews>false</peer_reviews>
+    <automatic_peer_reviews>false</automatic_peer_reviews>
+    <anonymous_peer_reviews>false</anonymous_peer_reviews>
+    <grade_group_students_individually>false</grade_group_students_individually>
+    <freeze_on_copy>false</freeze_on_copy>
+    <omit_from_final_grade>false</omit_from_final_grade>
+    <hide_in_gradebook>false</hide_in_gradebook>
+    <intra_group_peer_reviews>false</intra_group_peer_reviews>
+    <only_visible_to_overrides>false</only_visible_to_overrides>
+    <post_to_sis>false</post_to_sis>
+    <moderated_grading>false</moderated_grading>
+    <grader_count>0</grader_count>
+    <grader_comments_visible_to_graders>true</grader_comments_visible_to_graders>
+    <anonymous_grading>false</anonymous_grading>
+    <graders_anonymous_to_graders>false</graders_anonymous_to_graders>
+    <grader_names_visible_to_final_grader>true</grader_names_visible_to_final_grader>
+    <anonymous_instructor_annotations>false</anonymous_instructor_annotations>
+    <post_policy>
+      <post_manually>false</post_manually>
+    </post_policy>
+  </assignment>
+  <assignment_group_identifierref>g04d49ceb59ea2cc26e3d46c763506da7</assignment_group_identifierref>
+  <assignment_overrides>
+  </assignment_overrides>
+</quiz>

--- a/test/qti/Mod2ReadingQuiz/g3e9bef852d702d51e2f7d73269ed2023/g3e9bef852d702d51e2f7d73269ed2023.xml
+++ b/test/qti/Mod2ReadingQuiz/g3e9bef852d702d51e2f7d73269ed2023/g3e9bef852d702d51e2f7d73269ed2023.xml
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment ident="g3e9bef852d702d51e2f7d73269ed2023" title="Module 2 Reading Quiz">
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>cc_maxattempts</fieldlabel>
+        <fieldentry>1</fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+    <section ident="root_section">
+      <item ident="gc30987271c568fa979b38bbd3872af72" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_choice_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>20.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>9950,82371,73989,17052</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>g23f4dfcb23f37e28a561d54fe6d66820</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;div&gt;1.000 mm =&amp;nbsp;________&lt;/div&gt;</mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="9950">
+                <material>
+                  <mattext texttype="text/plain">1,000. m</mattext>
+                </material>
+              </response_label>
+              <response_label ident="82371">
+                <material>
+                  <mattext texttype="text/plain">0.001000 m</mattext>
+                </material>
+              </response_label>
+              <response_label ident="73989">
+                <material>
+                  <mattext texttype="text/plain">0.01000 m</mattext>
+                </material>
+              </response_label>
+              <response_label ident="17052">
+                <material>
+                  <mattext texttype="text/plain">100.0 m</mattext>
+                </material>
+              </response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal" />
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <varequal respident="response1">82371</varequal>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+      <item ident="ge06a8fd91cf36624085db35832137c60" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>20.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>30311,27580,42060,538</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>g13ea19571b4ac031a2dde0b39ecfbf58</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;div&gt;Which of the following numbers are exact numbers?&amp;nbsp;Select as many that apply.&lt;/div&gt;</mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Multiple">
+            <render_choice>
+              <response_label ident="30311">
+                <material>
+                  <mattext texttype="text/plain">40,589 tickets were sold at a baseball game</mattext>
+                </material>
+              </response_label>
+              <response_label ident="27580">
+                <material>
+                  <mattext texttype="text/plain">15 g of sucrose (sugar) were weighed out to bake a cake</mattext>
+                </material>
+              </response_label>
+              <response_label ident="42060">
+                <material>
+                  <mattext texttype="text/plain">2 L of water on average are consumed by humans each day</mattext>
+                </material>
+              </response_label>
+              <response_label ident="538">
+                <material>
+                  <mattext texttype="text/plain">10 eggs were used to prepare breakfast</mattext>
+                </material>
+              </response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal" />
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <and>
+                <varequal respident="response1">30311</varequal>
+                <not>
+                  <varequal respident="response1">27580</varequal>
+                </not>
+                <not>
+                  <varequal respident="response1">42060</varequal>
+                </not>
+                <varequal respident="response1">538</varequal>
+              </and>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+      <item ident="gc37a8185305cb60a22fafc9c8058e85b" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>calculated_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>20.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>e3e4b001340d467c98b693b810d85eb4,0fe044bb1e8d4b588a7a322b53d31de0,6a61c1c8ede64e50b2352a8ae4457b7f,9df1da01620742b9adf743f501f3cac6,82bfd75de2b845e6a597540bc2fef36a,94f8c7c61e2e401ebbf50a9359418561,2571f7d529cc4e45bdaa341fdf84f697,831e00309ac4431297876349df1f496c,20c5fa603b3c4a44970e2bf0593dae0c,bcb616130e4c4850915e3d9908c02fd5,ef1aad654f8c48c19a4f70b280b9cffa,e302a548e68b446eb7dd7e4e59f9897a,04b9a86c558c4b6092dd413e3ca4c4a2,f4f660ae59b74d3cae978160db515730,01037e6b2dbc4e359d5fa4ae25e4e535,0e7ffcb9f63c43c2bd8dcd944e12e0ba,d09b643d79034228980865b8ba0af197,cdfe28890bf44443aadafa04c5dd9ab7,7e1dbe2e01684bdd8278f008e0a087e5,77ac566aaacc4809a95d2c00181dda52,a2bded68afc448e38e9e0fd05702cd17,53c2a83995ea40f2bb5abcdc88712d57,fa944a21187645069259fb41963ae391,4f9976b8e8f444a599e943739365a482,b053cb211c71425aaf4abd0a5ef9ed0b,6d4e376694ed48c8a33067513fbb2b96,6c00484b442d4f6e816a2e4daaafdb9b,9e2f7f2a92944371a3b426c47e84681c,03978a9ae5ce44499c8a045eccf1852a,acf4fc33bfcd4a54889ffcb08e553302</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>g52365a8f3a23327e128ebad9720c2ba6</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;div&gt;What is the density (g/cm&lt;sup&gt;3&lt;/sup&gt;) of an object that has a volume of [x]&amp;nbsp;cm&lt;sup&gt;3&lt;/sup&gt; and a mass of [y]&amp;nbsp;g? Do not include units.&amp;nbsp;Report your answer to the correct number of significant figures.&lt;/div&gt;</mattext>
+          </material>
+          <response_str ident="response1" rcardinality="Single">
+            <render_fib fibtype="Decimal">
+              <response_label ident="answer1" />
+            </render_fib>
+          </response_str>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal" />
+          </outcomes>
+          <respcondition title="correct">
+            <conditionvar>
+              <other />
+            </conditionvar>
+            <setvar varname="SCORE" action="Set">100</setvar>
+          </respcondition>
+          <respcondition title="incorrect">
+            <conditionvar>
+              <not>
+                <other />
+              </not>
+            </conditionvar>
+            <setvar varname="SCORE" action="Set">0</setvar>
+          </respcondition>
+        </resprocessing>
+        <itemproc_extension>
+          <calculated>
+            <answer_tolerance>1.0</answer_tolerance>
+            <formulas decimal_places="">
+              <formula>&amp;lt;math xmlns="http://www.w3.org/1998/Math/MathML"&amp;gt;&amp;lt;mi
+          mathvariant="normal"&amp;gt;y&amp;lt;/mi&amp;gt;&amp;lt;mo&amp;gt;&amp;amp;#xF7;&amp;lt;/mo&amp;gt;&amp;lt;mi
+          mathvariant="normal"&amp;gt;x&amp;lt;/mi&amp;gt;&amp;lt;/math&amp;gt;</formula>
+            </formulas>
+            <vars>
+              <var name="x" scale="1">
+                <min>30.0</min>
+                <max>40.0</max>
+              </var>
+              <var name="y" scale="1">
+                <min>15.0</min>
+                <max>25.0</max>
+              </var>
+            </vars>
+            <var_sets>
+              <var_set ident="e3e4b001340d467c98b693b810d85eb4">
+                <var name="x">37.9</var>
+                <var name="y">22.5</var>
+                <answer>0.594</answer>
+              </var_set>
+              <var_set ident="0fe044bb1e8d4b588a7a322b53d31de0">
+                <var name="x">38.5</var>
+                <var name="y">21.8</var>
+                <answer>0.566</answer>
+              </var_set>
+              <var_set ident="6a61c1c8ede64e50b2352a8ae4457b7f">
+                <var name="x">37.9</var>
+                <var name="y">21.3</var>
+                <answer>0.562</answer>
+              </var_set>
+              <var_set ident="9df1da01620742b9adf743f501f3cac6">
+                <var name="x">33.7</var>
+                <var name="y">16.8</var>
+                <answer>0.499</answer>
+              </var_set>
+              <var_set ident="82bfd75de2b845e6a597540bc2fef36a">
+                <var name="x">34.1</var>
+                <var name="y">16.1</var>
+                <answer>0.472</answer>
+              </var_set>
+              <var_set ident="94f8c7c61e2e401ebbf50a9359418561">
+                <var name="x">30.7</var>
+                <var name="y">16.4</var>
+                <answer>0.534</answer>
+              </var_set>
+              <var_set ident="2571f7d529cc4e45bdaa341fdf84f697">
+                <var name="x">30.8</var>
+                <var name="y">24.3</var>
+                <answer>0.789</answer>
+              </var_set>
+              <var_set ident="831e00309ac4431297876349df1f496c">
+                <var name="x">38.2</var>
+                <var name="y">23.5</var>
+                <answer>0.615</answer>
+              </var_set>
+              <var_set ident="20c5fa603b3c4a44970e2bf0593dae0c">
+                <var name="x">30.5</var>
+                <var name="y">20.6</var>
+                <answer>0.675</answer>
+              </var_set>
+              <var_set ident="bcb616130e4c4850915e3d9908c02fd5">
+                <var name="x">36.6</var>
+                <var name="y">19.2</var>
+                <answer>0.525</answer>
+              </var_set>
+              <var_set ident="ef1aad654f8c48c19a4f70b280b9cffa">
+                <var name="x">39.2</var>
+                <var name="y">21.3</var>
+                <answer>0.543</answer>
+              </var_set>
+              <var_set ident="e302a548e68b446eb7dd7e4e59f9897a">
+                <var name="x">38.9</var>
+                <var name="y">17.6</var>
+                <answer>0.452</answer>
+              </var_set>
+              <var_set ident="04b9a86c558c4b6092dd413e3ca4c4a2">
+                <var name="x">38.8</var>
+                <var name="y">19.2</var>
+                <answer>0.495</answer>
+              </var_set>
+              <var_set ident="f4f660ae59b74d3cae978160db515730">
+                <var name="x">37.4</var>
+                <var name="y">17.8</var>
+                <answer>0.476</answer>
+              </var_set>
+              <var_set ident="01037e6b2dbc4e359d5fa4ae25e4e535">
+                <var name="x">30.8</var>
+                <var name="y">24.3</var>
+                <answer>0.789</answer>
+              </var_set>
+              <var_set ident="0e7ffcb9f63c43c2bd8dcd944e12e0ba">
+                <var name="x">35.1</var>
+                <var name="y">22.9</var>
+                <answer>0.652</answer>
+              </var_set>
+              <var_set ident="d09b643d79034228980865b8ba0af197">
+                <var name="x">38.4</var>
+                <var name="y">15.5</var>
+                <answer>0.404</answer>
+              </var_set>
+              <var_set ident="cdfe28890bf44443aadafa04c5dd9ab7">
+                <var name="x">39.3</var>
+                <var name="y">21.1</var>
+                <answer>0.537</answer>
+              </var_set>
+              <var_set ident="7e1dbe2e01684bdd8278f008e0a087e5">
+                <var name="x">34.4</var>
+                <var name="y">24.3</var>
+                <answer>0.706</answer>
+              </var_set>
+              <var_set ident="77ac566aaacc4809a95d2c00181dda52">
+                <var name="x">33.2</var>
+                <var name="y">16.3</var>
+                <answer>0.491</answer>
+              </var_set>
+              <var_set ident="a2bded68afc448e38e9e0fd05702cd17">
+                <var name="x">36.6</var>
+                <var name="y">22.2</var>
+                <answer>0.607</answer>
+              </var_set>
+              <var_set ident="53c2a83995ea40f2bb5abcdc88712d57">
+                <var name="x">33.4</var>
+                <var name="y">17.9</var>
+                <answer>0.536</answer>
+              </var_set>
+              <var_set ident="fa944a21187645069259fb41963ae391">
+                <var name="x">37.5</var>
+                <var name="y">21.6</var>
+                <answer>0.576</answer>
+              </var_set>
+              <var_set ident="4f9976b8e8f444a599e943739365a482">
+                <var name="x">36.6</var>
+                <var name="y">19.3</var>
+                <answer>0.527</answer>
+              </var_set>
+              <var_set ident="b053cb211c71425aaf4abd0a5ef9ed0b">
+                <var name="x">39.1</var>
+                <var name="y">18.8</var>
+                <answer>0.481</answer>
+              </var_set>
+              <var_set ident="6d4e376694ed48c8a33067513fbb2b96">
+                <var name="x">38.9</var>
+                <var name="y">18.1</var>
+                <answer>0.465</answer>
+              </var_set>
+              <var_set ident="6c00484b442d4f6e816a2e4daaafdb9b">
+                <var name="x">38.6</var>
+                <var name="y">17.2</var>
+                <answer>0.446</answer>
+              </var_set>
+              <var_set ident="9e2f7f2a92944371a3b426c47e84681c">
+                <var name="x">39.9</var>
+                <var name="y">24.8</var>
+                <answer>0.622</answer>
+              </var_set>
+              <var_set ident="03978a9ae5ce44499c8a045eccf1852a">
+                <var name="x">34.7</var>
+                <var name="y">19.8</var>
+                <answer>0.571</answer>
+              </var_set>
+              <var_set ident="acf4fc33bfcd4a54889ffcb08e553302">
+                <var name="x">38.4</var>
+                <var name="y">22.2</var>
+                <answer>0.578</answer>
+              </var_set>
+            </var_sets>
+          </calculated>
+        </itemproc_extension>
+      </item>
+      <section ident="g8e10aa11516738e3d511ac22395832cf" title="Question Group">
+        <selection_ordering>
+          <selection>
+            <selection_number>1</selection_number>
+            <selection_extension>
+              <points_per_item>1.0</points_per_item>
+            </selection_extension>
+          </selection>
+        </selection_ordering>
+        <item ident="g0a3bfd4bae58efe0d2fc45f06b32ebce" title="Question">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_dropdowns_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>points_possible</fieldlabel>
+                <fieldentry>0.0</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>original_answer_ids</fieldlabel>
+                <fieldentry>62759,21608,6152,10359,46387,97981,62342,73866,17436,90834,4998</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>assessment_question_identifierref</fieldlabel>
+                <fieldentry>g218c23f74018e13076918a43ef7d2a10</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">&lt;div&gt;There are [a] significant figures in the measurement 0.004870 L.&lt;/div&gt;</mattext>
+            </material>
+            <response_lid ident="response_a">
+              <material>
+                <mattext>a</mattext>
+              </material>
+              <render_choice>
+                <response_label ident="62759">
+                  <material>
+                    <mattext texttype="text/plain">choose one</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="21608">
+                  <material>
+                    <mattext texttype="text/plain">0</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="6152">
+                  <material>
+                    <mattext texttype="text/plain">1</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="10359">
+                  <material>
+                    <mattext texttype="text/plain">2</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="46387">
+                  <material>
+                    <mattext texttype="text/plain">3</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="97981">
+                  <material>
+                    <mattext texttype="text/plain">4</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="62342">
+                  <material>
+                    <mattext texttype="text/plain">5</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="73866">
+                  <material>
+                    <mattext texttype="text/plain">6</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="17436">
+                  <material>
+                    <mattext texttype="text/plain">7</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="90834">
+                  <material>
+                    <mattext texttype="text/plain">8</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="4998">
+                  <material>
+                    <mattext texttype="text/plain">9</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal" />
+            </outcomes>
+            <respcondition>
+              <conditionvar>
+                <varequal respident="response_a">97981</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Add">100.00</setvar>
+            </respcondition>
+          </resprocessing>
+        </item>
+      </section>
+      <item ident="g8a6161026794a8a31da5ac38e22c370b" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>numerical_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>20.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>87992</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>g0e20eee49399d91e9dcaa33aae033676</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;div&gt;&lt;p&gt;Yeast converts glucose to ethanol and carbon dioxide as depicted in the simplified chemical equation here: &lt;span id="MathJax-Span-429"&gt;&lt;span id="MathJax-Span-430"&gt;&lt;span id="MathJax-Span-431"&gt;&lt;span id="MathJax-Span-432"&gt;&lt;span id="MathJax-Span-433"&gt;&lt;span id="MathJax-Span-434"&gt;glucose &lt;/span&gt;&lt;span id="MathJax-Span-435"&gt;&lt;/span&gt;&lt;span id="MathJax-Span-436"&gt;⟶ &lt;/span&gt;&lt;span id="MathJax-Span-437"&gt;&lt;/span&gt;&lt;span id="MathJax-Span-438"&gt;ethanol &lt;/span&gt;&lt;span id="MathJax-Span-439"&gt;+ &lt;/span&gt;&lt;span id="MathJax-Span-440"&gt;carbon dioxide.&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;&lt;/p&gt; 
+&lt;p&gt;&lt;span&gt;If 500 g of glucose is fully converted, what will be the total mass of products ethanol and carbon dioxide produced? Report your answer to the ones place and do not include units.&lt;/span&gt;&lt;/p&gt;&lt;/div&gt;</mattext>
+          </material>
+          <response_str ident="response1" rcardinality="Single">
+            <render_fib fibtype="Decimal">
+              <response_label ident="answer1" />
+            </render_fib>
+          </response_str>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal" />
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <vargte respident="response1">500.0</vargte>
+              <varlte respident="response1">500.0</varlte>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>

--- a/test/qti/Mod2ReadingQuiz/imsmanifest.xml
+++ b/test/qti/Mod2ReadingQuiz/imsmanifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest identifier="ge81d5ebf66a08e257d5b704f1abe1eda" xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1" xmlns:lom="http://ltsc.ieee.org/xsd/imsccv1p1/LOM/resource" xmlns:imsmd="http://www.imsglobal.org/xsd/imsmd_v1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1 http://www.imsglobal.org/xsd/imscp_v1p1.xsd http://ltsc.ieee.org/xsd/imsccv1p1/LOM/resource http://www.imsglobal.org/profile/cc/ccv1p1/LOM/ccv1p1_lomresource_v1p0.xsd http://www.imsglobal.org/xsd/imsmd_v1p2 http://www.imsglobal.org/xsd/imsmd_v1p2p2.xsd">
+  <metadata>
+    <schema>IMS Content</schema>
+    <schemaversion>1.1.3</schemaversion>
+    <imsmd:lom>
+      <imsmd:general>
+        <imsmd:title>
+          <imsmd:string>QTI Quiz Export for course "Principles of Computing"</imsmd:string>
+        </imsmd:title>
+      </imsmd:general>
+      <imsmd:lifeCycle>
+        <imsmd:contribute>
+          <imsmd:date>
+            <imsmd:dateTime>2025-01-31</imsmd:dateTime>
+          </imsmd:date>
+        </imsmd:contribute>
+      </imsmd:lifeCycle>
+      <imsmd:rights>
+        <imsmd:copyrightAndOtherRestrictions>
+          <imsmd:value>yes</imsmd:value>
+        </imsmd:copyrightAndOtherRestrictions>
+        <imsmd:description>
+          <imsmd:string>Private (Copyrighted) - http://en.wikipedia.org/wiki/Copyright</imsmd:string>
+        </imsmd:description>
+      </imsmd:rights>
+    </imsmd:lom>
+  </metadata>
+  <organizations/>
+  <resources>
+    <resource identifier="g3e9bef852d702d51e2f7d73269ed2023" type="imsqti_xmlv1p2">
+      <file href="g3e9bef852d702d51e2f7d73269ed2023/g3e9bef852d702d51e2f7d73269ed2023.xml"/>
+      <dependency identifierref="g9d9c8f0f91ca0d603260ae88e614290f"/>
+    </resource>
+    <resource identifier="g9d9c8f0f91ca0d603260ae88e614290f" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="g3e9bef852d702d51e2f7d73269ed2023/assessment_meta.xml">
+      <file href="g3e9bef852d702d51e2f7d73269ed2023/assessment_meta.xml"/>
+    </resource>
+  </resources>
+</manifest>

--- a/test/remove-reundundant-input-test.ts
+++ b/test/remove-reundundant-input-test.ts
@@ -22,13 +22,13 @@ describe('removeRedundantInputRefs', () => {
 
   it('should remove inputRefs with the specified input ID', () => {
     const input = [
-      { type: 'input_ref', input: 'redundantId' },
-      { type: 'input_ref', input: 'otherId' },
+      { type: 'input_ref', id: 'redundantId' },
+      { type: 'input_ref', id: 'otherId' },
       { text: 'not an input_ref' },
     ];
     const result = removeRedundantInputRefs(input, 'redundantId');
     expect(result).toEqual([
-      { type: 'input_ref', input: 'otherId' },
+      { type: 'input_ref', id: 'otherId' },
       { text: 'not an input_ref' },
     ]);
   });
@@ -38,11 +38,11 @@ describe('removeRedundantInputRefs', () => {
       {
         type: 'parent',
         children: [
-          { type: 'input_ref', input: 'redundantId' },
+          { type: 'input_ref', id: 'redundantId' },
           { text: 'not an input_ref' },
         ],
       },
-      { type: 'input_ref', input: 'otherId' },
+      { type: 'input_ref', id: 'otherId' },
     ];
     const result = removeRedundantInputRefs(input, 'redundantId');
     expect(result).toEqual([
@@ -50,7 +50,7 @@ describe('removeRedundantInputRefs', () => {
         type: 'parent',
         children: [{ text: 'not an input_ref' }],
       },
-      { type: 'input_ref', input: 'otherId' },
+      { type: 'input_ref', id: 'otherId' },
     ]);
   });
 
@@ -108,7 +108,7 @@ describe('removeRedundantInputRefs', () => {
 
         expect(
           stem.content[2].children.find(
-            (c: any) => c.type === 'input_ref' && c.input === 'A'
+            (c: any) => c.type === 'input_ref' && c.id === 'A'
           )
         ).toBeDefined(); // Make sure it kept that input_ref
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,6 +872,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.9.1":
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"
+  integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@^5.16.0":
   version "5.29.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz"
@@ -1340,7 +1347,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-crc32@^0.2.1, buffer-crc32@^0.2.13:
+buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
   integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
@@ -2134,6 +2141,17 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -2178,6 +2196,13 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 fetch-ponyfill@^7.1.0:
   version "7.1.0"
@@ -2321,9 +2346,9 @@ get-stream@^4.0.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^5.0.0:
+get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
-  resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
@@ -3767,6 +3792,11 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
@@ -4971,6 +5001,14 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This adds a mode of the migration tool to convert QTI format exports of questions. It is invoked by operation argument `qti` and otherwise takes same parameters as the `convert `operation.
  ` npm start -- qti -i inputDir`
`inputDir` should be path to a folder containing one or more QTI packages in .zip format (must have this extension). Note spaces required on both sides of the double-hyphen which serves as a separator. 

This will add all convertible questions into an ingestible archive as activity bank items. Question types handled are Multiple Choice, Check All That Apply, Dropdown items (maybe multiple), Short Answer numeric, and Short Answer numeric with dynamic variables (corresponding to Canvas "calculated" question types). All items receive default scoring. Questions are tagged with the title of the assessment they came from. 

This version handles QTI version 1.2 as exported by Canvas. It has also been tested on exports from Blackboard in the same version, though they are slightly different. It detects QTI 2.* files and prints a message.

Some known limits: Questions with images or other media were not in our sample set; these are not handled. 
The conversion of calculated questions may be fragile since the answer formula is arbitrary mathML.

This PR takes the opportunity to adjust command line arguments slightly. Also adjusts processing of `input_ref `elements to avoid passing through confusing "input" attribute from legacy, which has no role in torus. 