### PR TITLE
[BUG FIX] [MER-4427] fix missing learning objectives in some courses

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -324,7 +324,7 @@ export function globalizeObjectiveReferences(
   resources: TorusResource[]
 ): TorusResource[] {
   // Make a map of the local to global.  The global id is of the form:
-  // local|suffix, where local is the id of the objective, and suffix is the
+  // local-suffix, where local is the id of the objective, and suffix is the
   // id of the parent <objectives> element
   const localToGlobal = resources.reduce((m: any, r: TorusResource) => {
     if (r.type === 'Objective') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,11 +240,14 @@ export function convertAction(options: CmdOptions): Promise<ConvertedResults> {
 
     const orgPaths = [...results[1].organizationPaths];
 
+    // A quirk of executeSerially is that elements of list-valued functions get *spliced*
+    // into the collective result. So while results[0] and [1] are objects, rest of results
+    // list consists of learning objective resource ids followed by skill resource ids.
+    // Therefore results.slice(2) includes all of them in the list of references to process.
     const references = [
       ...orgReferences,
       ...orgReferencesOthers,
       ...results.slice(2),
-      ...results.slice(3),
     ];
 
     const mediaSummary: Media.MediaSummary = {

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -690,6 +690,16 @@ export function performRestructure($: any) {
       )
   );
 
+  // Found some single-part questions listing skillrefs at question level.
+  // Insert copies into question's parts where processing expects them
+  $('question').each((_i: any, q: any) =>
+    $(q)
+      .find('>skillref')
+      .each((_i: any, skillref: any) =>
+        $(q).find('part').prepend($.html(skillref))
+      )
+  );
+
   migrateVariables($);
 }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -14,7 +14,7 @@ export function replaceAll(s: string, t: string, w: string) {
 
 // Take an array of functions that return promises and
 // execute them serially, resolving an array of their
-// resolutions. Note: results formed by successive concatenation, so if
+// resolutions. NOTE: results formed by successive concatenation, so if
 // individual function result is array, its contents are spliced in
 export const executeSerially = (funcs: any) =>
   funcs.reduce(


### PR DESCRIPTION
Some activities in migrated Concepts of Statistics course wound up missing their learning objectives. 

Found this happening on fill in the blank questions on which the XML listed the skillrefs _outside_ of a part. Migration tool expects the skillrefs to be _inside_ the part because each part in a multi-part question may involve different skills. The cases where this was found were in fact single part dropdown questions, so it is not semantically necessary in this case, and perhaps legacy allowed this. Fix is to adjust migration tool to allow for this.

While investigating this issue, also identified a subtle coding issue which caused all but the first item in the inventoried list of x-oli-learning_objectives + x-oli-skills_model resources to be processed twice. This stemmed from an easy-to-overlook quirk in the `executeSerially` utility routines which executes a list of promise-valued functions in order and returns a concatenated list of results. Because of the way `executeSerially` is coded, list-valued functions have their results *spliced* into the list of results. So, for example, the result of executeSerially on a list of 4 functions is not necessarily an array of four results. Where functions 3 and 4 return lists of items (our case), the tail of the result array consists of the concatenation of the results returned by functions 3 and 4.

It is not clear if processing the LO resources twice ever caused any problems. It may well be completely harmless. But processing twice is wasteful. And it could potentially lead to duplicates with different generated unique ids, which can cause problems. In any case, this is fixed with an explanatory comment. 

 