### PR TITLE
[BUG FIX] [MER-4804] Preserve catchAll feedback on CATA questions

### DIFF
--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -272,7 +272,7 @@ export function cata(question: any, from = 'multiple_choice') {
       id: guid(),
       score: 0,
       rule: '.*', // legacy match pattern awaiting translation below
-      feedback: Common.makeFeedback('Correct'),
+      feedback: Common.makeFeedback('Incorrect'),
     });
   }
 

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -36,7 +36,9 @@ export function convertAutoGenResponses(model: any) {
       );
 
     const catchAll = autoGens[0];
-    catchAll.rule = 'input like {.*}';
+    // This is used at stage in which rule is provisionally filled with a
+    // catchAll-normalized legacy match pattern to be converted, not a torus rule.
+    catchAll.rule = '.*';
     model.authoring.parts[0].responses.push(catchAll);
   }
 }


### PR DESCRIPTION
Migrated CATA questions were not getting the proper catchAll incorrect feedback. This was due to a bug in the handling of Echo autogenerated responses, which does attempt to replace the large set of autogenerated responses with a single catchAll, preserving the specified feedback. 

The bug was due to a subtlety introduced into the processing of cata questions at some point, so that it occurs in two stages: an initial stage at which the "rule" field of the response provisionally stores the legacy match pattern, and a later stage that translates all response rules into torus rules. The autogen conversion occurred in stage one, but the result was not in the form of the initial stage so wound up unrecognized as the catchall by the later processing, leading to the tool filling in a catchall response with default feedback. 

In addition, there was a typo so that tool-supplied catchall for a CATA question to have the feedback "Correct" rather than "Incorrect". But the main issue was the loss of the original catchAll replacing the autogens where those were used.