### PR TITLE
[BUG FIX] [MEr-4879] always set shuffle on ordering questions

### DIFF
--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -297,7 +297,6 @@ function getHotspots(imageHotspot: any) {
 }
 
 function ordering(question: any) {
-  const shuffle = Common.getChild(question, 'ordering').shuffle;
   const transformationElement = Common.getChild(question, 'transformation');
   const transformationsArray =
     transformationElement === undefined ? [] : [transformationElement];
@@ -309,7 +308,8 @@ function ordering(question: any) {
       version: 2,
       parts: [buildOrderingPart(question)],
       transformations: [
-        ...(shuffle === 'true' ? [Common.shuffleTransformation()] : []),
+        // no shuffle attribute, just always set on this question type
+        Common.shuffleTransformation(),
         ...transformationsArray,
       ],
       previewText: '',
@@ -764,7 +764,6 @@ export class Formative extends Resource {
           r.children[0].children,
           this.file
         );
-
         resolve(items);
       });
     });


### PR DESCRIPTION
Migration tool was coded to look for a "shuffle" attribute on ordering questions and pass its value through, just as for multiple choice questions. However, legacy ordering questions did not carry such an attribute. Rather, legacy ordering questions were *always* shuffled. This changes to always set a shuffle transformation when migrating ordering questions to reproduce the legacy behavior. 