### PR TITLE
[BUG FIX][MER-4959] migrate video subtitle file references to torus format

### DIFF
--- a/src/resources/common.ts
+++ b/src/resources/common.ts
@@ -343,6 +343,9 @@ export function standardContentManipulations($: any) {
   DOM.renameAttribute($, 'video source', 'src', 'url');
   DOM.renameAttribute($, 'video', 'type', 'contenttype');
   DOM.renameAttribute($, 'audio', 'type', 'audioType');
+  // video <track> subelement with .vtt subtitle file => torus captions child
+  DOM.rename($, 'video track[kind="subtitles"]', 'captions');
+  DOM.renameAttribute($, 'video captions', 'srclang', 'language_code');
 
   DOM.rename($, 'extra', 'popup');
 

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -399,6 +399,17 @@ export function toJSON(
           } else {
             top().src = getAllOfType(top().children, 'source');
           }
+          // video may carry vtt subtitle file(s) in captions children
+          const captions = getAllOfType(top().children, 'captions');
+          if (captions != null && captions.length > 0) {
+            top().captions = captions.map((c: any) => {
+              return {
+                label: c.label,
+                language_code: c.language_code,
+                src: c.src,
+              };
+            });
+          }
 
           top().children = [{ text: ' ' }];
           if (top().width !== undefined) {


### PR DESCRIPTION
Legacy video elements may include <track> sub-elements specifying a .vtt format file containing subtitles (aka closed captions). These were not being processed. This PR migrates the subtitles to the torus format, a "captions" attribute on video elements. 