### PR TITLE
[ENHANCEMENT] [MER-4991] handle conventions in french1 skills spreadsheet

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -183,12 +183,14 @@ function applyMagic(resources: TorusResource[], m: Magic.MagicSpreadsheet) {
     } else {
       let errorDetail = '';
       let activity = byActivityId[a.resourceId + '-' + a.questionId];
+      console.log('found by full id: ' + a.resourceId + '-' + a.questionId);
       if (activity === undefined) {
         // Could not find directly, see if we can find it by strictly the question id
         // !!! Assumes some uniquifying id conventions, else could have id=q1 in two assessments
         activity = Object.values(byActivityId).find((ac: TorusResource) =>
           ac.id.endsWith('-' + a.questionId)
         );
+        if (activity) console.log('found by qid tail:' + a.questionId);
       }
       if (activity === undefined) {
         // try convention found in french1 sheet: questionId of form resourceId_qId where qId
@@ -196,7 +198,7 @@ function applyMagic(resources: TorusResource[], m: Magic.MagicSpreadsheet) {
         // This primarily for pools, since pool id nowhere else in sheet, but also used for assessments
         const matches = a.questionId.match(/(.*)_(q\w+)$/);
         if (matches) {
-          const [_ignore, resourceId, qId] = matches;
+          const [, resourceId, qId] = matches;
           const isPool =
             resources.find((r) => r.id === resourceId)?.type === 'Tag';
           // get list of activities within this resource
@@ -211,7 +213,10 @@ function applyMagic(resources: TorusResource[], m: Magic.MagicSpreadsheet) {
           if (resourceActivities.length === 0) {
             errorDetail = `No activities converted for ${resourceId}, may not be referenced`;
           } else {
-            // console.log('searching qids: ' + resourceActivities.map((a) => a.id.split('_').pop()));
+            console.log(
+              `searching for ${qId} among qids: ` +
+                resourceActivities.map((a) => a.id.split('_').pop())
+            );
             // Found that full id of pool questions may differ, but can match on _qId tail
             if (isPool) {
               activity = resourceActivities.find((a) =>

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -150,6 +150,7 @@ function applyMagic(resources: TorusResource[], m: Magic.MagicSpreadsheet) {
     }
     return m;
   }, {});
+
   m.attachments.forEach((a: Magic.SpreadsheetAttachment) => {
     // If the question id is null, we apply the attached skills to all questions in the resource
     if (a.questionId === null) {
@@ -180,13 +181,53 @@ function applyMagic(resources: TorusResource[], m: Magic.MagicSpreadsheet) {
         );
       });
     } else {
+      let errorDetail = '';
       let activity = byActivityId[a.resourceId + '-' + a.questionId];
       if (activity === undefined) {
         // Could not find directly, see if we can find it by strictly the question id
+        // !!! Assumes some uniquifying id conventions, else could have id=q1 in two assessments
         activity = Object.values(byActivityId).find((ac: TorusResource) =>
           ac.id.endsWith('-' + a.questionId)
         );
       }
+      if (activity === undefined) {
+        // try convention found in french1 sheet: questionId of form resourceId_qId where qId
+        // allows matching to question within containing legacy pool or assessment w/id resourceId
+        // This primarily for pools, since pool id nowhere else in sheet, but also used for assessments
+        const matches = a.questionId.match(/(.*)_(q\w+)$/);
+        if (matches) {
+          const [_ignore, resourceId, qId] = matches;
+          const isPool =
+            resources.find((r) => r.id === resourceId)?.type === 'Tag';
+          // get list of activities within this resource
+          const resourceActivities = isPool
+            ? resources.filter(
+                (r) => r.type === 'Activity' && r.tags.includes(resourceId)
+              )
+            : resources.filter(
+                (r) =>
+                  r.type === 'Activity' && r.id.startsWith(resourceId + '-')
+              );
+          if (resourceActivities.length === 0) {
+            errorDetail = `No activities converted for ${resourceId}, may not be referenced`;
+          } else {
+            // console.log('searching qids: ' + resourceActivities.map((a) => a.id.split('_').pop()));
+            // Found that full id of pool questions may differ, but can match on _qId tail
+            if (isPool) {
+              activity = resourceActivities.find((a) =>
+                a.id.endsWith(`_${qId}`)
+              );
+            } else {
+              // found qIds in assessments may have been renumbered from different base, eg q65, q66, q77
+              // but qIds like q1, q2, q3 used in sheet work to determine an ordinal (1-based index)
+              const nth = Number.parseInt(qId.substring(1));
+              // Activity order within legacy assessment is preserved in resource list here
+              activity = resourceActivities[nth - 1];
+            }
+          }
+        }
+      }
+
       if (activity !== undefined) {
         const objectives = activity.objectives;
 
@@ -215,7 +256,7 @@ function applyMagic(resources: TorusResource[], m: Magic.MagicSpreadsheet) {
         }
       } else {
         console.log(
-          `warning: could not locate activity referenced from spreadsheet, resourceId: ${a.resourceId} questionId: ${a.questionId}`
+          `warning: could not locate activity referenced from spreadsheet, resourceId: ${a.resourceId} questionId: ${a.questionId} ${errorDetail}`
         );
       }
     }

--- a/src/utils/spreadsheet.ts
+++ b/src/utils/spreadsheet.ts
@@ -188,9 +188,7 @@ function extractAttachments(wb: XLSX.WorkBook): SpreadsheetAttachment[] {
 
 function isValid(wb: XLSX.WorkBook) {
   return (
-    wb.Sheets['Skills'] &&
-    wb.Sheets['Problems'] &&
-    wb.Sheets['LOs'] &&
-    wb.Sheets['LO Ref']
+    wb.Sheets['Skills'] && wb.Sheets['Problems'] && wb.Sheets['LOs']
+    // && wb.Sheets['LO Ref']
   );
 }


### PR DESCRIPTION
Legacy courses could have a skills model specified in an external spreadsheet, sometimes referred to as a “Magic Spreadsheet”. The migration tool can optionally process these to attach Learning Objectives to resources in the course. 

However, the french1 spreadsheet uses certain coding conventions for identifying items in pools that the migration script does not process, identifying a problem by compound ids of the form `poolID_qId`, where qId is actually a suffix like q1, q2, q3 on the full id.  It also uses these conventions also for some assessment items, though it should not be necessary in the case of assessment questions. 

Additionally, migration script requires an LO Refs sheet, giving up processing if it is not found, but in fact this can be omitted and everything will still work as long as all LOs used by ID are defined in the course XML. (True in french1). 

This enhances spreadsheet processing to handle these conventions so french1 LOs can be attached to items in a  new migration. 