### PR TITLE
[ENHANCEMENT] preserve custom points on instructor-graded pool questions

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -644,6 +644,42 @@ export function fixWildcardSelections(resources: TorusResource[]) {
   return resources;
 }
 
+const getSelectionPoints = (resources: TorusResource[], sel: any) => {
+  const tag = sel.logic.conditions.children[0].value[0];
+  const acts = resources.filter(
+    (r) => r.type === 'Activity' && r.tags.includes(tag)
+  );
+
+  const partPoints = (act: any): number[] =>
+    act.content.authoring.parts.map((part: any) => part?.outOf || 1);
+
+  const actPoints = (act: any) =>
+    partPoints(act).reduce((sum: number, val: number) => sum + val, 0);
+
+  // we can only assign points to selection if all possible questions have same points
+  const firstActPoints = actPoints(acts[0]);
+  return acts.every((a) => actPoints(a) === firstActPoints)
+    ? firstActPoints
+    : 1;
+};
+
+export function setSelectionPoints(resources: TorusResource[]) {
+  resources
+    .filter((r) => r.type === 'Page')
+    .forEach((page) => {
+      getDescendants(
+        (page as Page).content.model as any[],
+        'selection'
+      ).forEach((sel: any) => {
+        const points = getSelectionPoints(resources, sel);
+        if (points !== 1) {
+          sel.pointsPerActivity = points;
+        }
+      });
+    });
+
+  return resources;
+}
 function fixReportActivityid(resources: TorusResource[], selection: any) {
   resources
     .filter((r) => r.type === 'Page' && r.id === selection.activityId)

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,7 @@ export function convertAction(options: CmdOptions): Promise<ConvertedResults> {
           updated = Convert.updateDerivativeReferences(updated);
           updated = Convert.generatePoolTags(updated);
           updated = Convert.fixWildcardSelections(updated);
+          updated = Convert.setSelectionPoints(updated);
           updated = Convert.fixActivityReports(updated);
           updated = filterOutTemporaryContent(updated);
           updated = Convert.updateNonDirectImageReferences(

--- a/src/resources/formative.ts
+++ b/src/resources/formative.ts
@@ -75,7 +75,6 @@ function buildMCQPart(question: any) {
         content: Common.ensureParagraphs(r.children),
       }))
     ),
-    scoringStrategy: 'average',
     targeted: [],
     objectives: skillrefs.map((s: any) => s.idref),
     explanation: Common.maybeBuildPartExplanation(responses),
@@ -161,7 +160,6 @@ function buildOrderingPart(question: any) {
         content: Common.ensureParagraphs(r.children),
       }))
     ),
-    scoringStrategy: 'average',
     objectives: skillrefs.map((s: any) => s.idref),
     explanation: Common.maybeBuildPartExplanation(responses),
   };
@@ -215,7 +213,6 @@ function buildLikertParts(question: any, items: any[]) {
       },
       Common.makeCatchAllResponse(),
     ],
-    scoringStrategy: 'average',
     objectives: [],
     targeted: [],
     explanation: null,
@@ -483,7 +480,7 @@ export function toActivity(
   }
 
   // add optional custom scoring attributes to model if needed
-  setCustomScoringFlags(model, activity.subType);
+  setCustomScoringFlags(model, activity.subType, activity.id);
 
   // collect refs from any internal links in stem content
   const links: any[] = Common.getDescendants(model.stem?.content, 'a');
@@ -553,10 +550,11 @@ export function titleActivity(
 }
 
 // add optional attributes to flag custom scoring to torus authoring
-export function setCustomScoringFlags(model: any, subType: string) {
+export function setCustomScoringFlags(model: any, subType: string, id: string) {
   const hasCustomPoints = model.authoring.parts.some(
     (p: any) => Common.getOutOfPoints(p) > 1
   );
+
   if (hasCustomPoints) {
     // For multi-part questions, authoring detects custom by activity-wide flag
     if (['oli_multi_input', 'oli_response_multi'].includes(subType))

--- a/src/resources/image.ts
+++ b/src/resources/image.ts
@@ -162,7 +162,6 @@ function defaultContent(example: boolean) {
               ],
             },
           ],
-          scoringStrategy: 'average',
         },
       ],
       transformations: [],

--- a/src/resources/questions/cata.ts
+++ b/src/resources/questions/cata.ts
@@ -204,7 +204,6 @@ export function buildCATAPart(question: any) {
         content: Common.ensureParagraphs(r.children),
       }))
     ),
-    scoringStrategy: 'average',
     objectives: skillrefs.map((s: any) => s.idref),
     explanation: Common.maybeBuildPartExplanation(responses),
     targeted: [],

--- a/src/resources/questions/common.ts
+++ b/src/resources/questions/common.ts
@@ -378,7 +378,6 @@ export function buildTextPart(id: string, question: any) {
       }))
     ),
     objectives: skillrefs.map((s: any) => s.idref),
-    scoringStrategy: 'average',
     explanation: maybeBuildPartExplanation(legacyResponses),
     gradingApproach: getGradingApproach(question),
   };
@@ -432,5 +431,9 @@ export function adjustSubmitCompareResponses(origResponses: any[]) {
 }
 
 export function getOutOfPoints(part: any) {
-  return Math.max(...part.responses.map((r: any) => r?.score ?? 0));
+  return (
+    // instructor-graded questions have no responses but may still have custom
+    // outOf points set from score_out_of attribute on legacy part
+    part?.outOf || Math.max(...part.responses.map((r: any) => r?.score ?? 0))
+  );
 }

--- a/src/resources/questions/multi.ts
+++ b/src/resources/questions/multi.ts
@@ -396,7 +396,6 @@ function buildDropdownPart(part: any, i: number, ignorePartId: boolean) {
       }))
     ),
     objectives: skillrefs.map((s: any) => s.idref),
-    scoringStrategy: 'average',
     explanation: Common.maybeBuildPartExplanation(responses),
   };
 }
@@ -461,7 +460,7 @@ export function buildInputPart(
   const skillrefs = Common.getChildren(part, 'skillref');
   const id = part.id !== undefined && part.id !== null ? part.id + '' : guid();
 
-  return {
+  const torusPart: any = {
     id,
     responses: responses.map((r: any) => {
       const cleanedMatch = convertCatchAll(r.match);
@@ -488,10 +487,15 @@ export function buildInputPart(
       }))
     ),
     objectives: skillrefs.map((s: any) => s.idref),
-    scoringStrategy: 'average',
     explanation: Common.maybeBuildPartExplanation(responses),
     gradingApproach: Common.getGradingApproach(input),
   };
+  // include custom outOf points for instructor-graded questions if specified by score_out_of attr
+  if (torusPart.gradingApproach === 'manual' && part?.score_out_of) {
+    torusPart.outOf = Number(part.score_out_of);
+  }
+
+  return torusPart;
 }
 
 // Build a response_multi question. Similar to multi-input, but each part subsumes a *set* of
@@ -611,7 +615,6 @@ const toResponseMultiPart = (part: any, items: any[]) => {
       }))
     ),
     objectives: skillrefs.map((s: any) => s.idref),
-    scoringStrategy: 'average',
     explanation: Common.maybeBuildPartExplanation(responses),
   };
 };

--- a/src/resources/superactivity.ts
+++ b/src/resources/superactivity.ts
@@ -265,7 +265,6 @@ function toActivityModel(
       parts: [
         {
           id: guid(),
-          scoringStrategy: 'average',
           responses: [],
           hints: [],
         },


### PR DESCRIPTION
Legacy instructor-graded pool questions for French carry custom point values via the score_out_of attribute, but these point values are not being preserved in migration. Instructor graded questions are the only questions that depend on this attribute for custom point values.

In addition, any custom points on pool questions are now overridden by the new pointsPerQuestion attribute on selection, which defaults to 1.

This updates the migration tool to do two things:

+ Carry through custom points from the score_out_of on instructor graded questions.

+ Set the points per question on selection statements where that is possible (all possible questions have the same non-default point value) so default pointsPerQuestion does not override custom points.

Note 2 is independent of 1 and is a general improvement for ALL pool selections, whether instructor graded or not.

This PR also takes the opportunity to remove the spurious scoringStrategy: "average" which was attached to parts in earlier versions of the code. This is not used by torus. 