### PR TITLE
Adds support for local minio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+AWS_ACCESS_KEY_ID=your-aws-access-key
+AWS_SECRET_ACCESS_KEY=your-aws-secret-key
+MEDIA_BUCKET_NAME=your-media-bucket-name
+
+# Local MinIO development
+MINIO_ROOT_USER=your-minio-root-user
+MINIO_ROOT_PASSWORD=your-minio-root-password
+MINIO_BUCKET_NAME=your-minio-bucket-name
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_MEDIA_URL_PREFIX=http://localhost:9000/<your-minio-bucket-name>/media

--- a/README.md
+++ b/README.md
@@ -15,11 +15,37 @@ npm start -- --operation convert --inputDir <course input dir>
 ```
 
 Optionally, you can specify a specific output directory. Defaults to `<inputDir>-out`
+
 ```
 npm start -- --operation convert --inputDir <course input dir> --outputDir ./out
 ```
 
 Before uploading media assets, you will need to configure AWS credentials and a bucket name.
 See detailed instructions in the [Wiki](https://github.com/Simon-Initiative/course-digest/wiki).
+
+For local OLI development against MinIO, the uploader now supports `--localMinio`
+and reads its MinIO settings from the repo root `.env` file. Add entries like:
+
+```bash
+MINIO_ROOT_USER=your_minio_access_key
+MINIO_ROOT_PASSWORD=your_minio_secret_key
+MINIO_BUCKET_NAME=torus-media-dev
+MINIO_ENDPOINT=http://localhost:9000
+# Optional if browser-facing media URLs differ from the API endpoint
+MINIO_MEDIA_URL_PREFIX=http://localhost:9000/torus-media-dev/media
+```
+
+Then run conversion with `--localMinio`. If `MINIO_MEDIA_URL_PREFIX` is omitted,
+the tool derives it from `MINIO_ENDPOINT` and the configured bucket:
+
+```bash
+npm run start -- convert --inputDir <course input dir> --localMinio
+```
+
+You can also upload an existing media manifest into local MinIO directly:
+
+```bash
+npm run start -- upload --mediaManifest <outputDir/_media-manifest.json> --localMinio
+```
 
 The tool can also be used to [convert questions exported in QTI format](https://github.com/Simon-Initiative/course-digest/wiki/QTI-Conversion-mode).

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ import * as path from 'path';
 import * as commandLineArgs from 'command-line-args';
 import { filesize } from 'filesize';
 import * as archiver from 'archiver';
-import { Maybe } from 'tsmonad';
 import * as Merge from './merge';
 import { glob } from 'glob';
 import extract = require('extract-zip');
@@ -51,6 +50,7 @@ const optionDefinitions = [
   { name: 'spreadsheetPath', type: String, alias: 's' },
   { name: 'svnRoot', type: String },
   { name: 'downloadRemote', type: Boolean, alias: 'r' },
+  { name: 'localMinio', type: Boolean },
   { name: 'mergePathA', type: String, alias: 'a' },
   { name: 'mergePathB', type: String, alias: 'b' },
   { name: 'discussionsOn', type: Boolean, alias: 'd' },
@@ -67,6 +67,7 @@ interface CmdOptions extends commandLineArgs.CommandLineOptions {
   inputDir: string;
   svnRoot: string;
   downloadRemote: boolean;
+  localMinio?: boolean;
   specificOrg: string;
   mediaUrlPrefix: string;
   mergePathA: string;
@@ -86,10 +87,36 @@ interface ConvertedResults {
   webContentBundle?: Media.WebContentBundle;
 }
 
+export function localMinioBucketName(): string {
+  return (
+    process.env.MINIO_BUCKET_NAME ||
+    process.env.MINIO_MEDIA_BUCKET_NAME ||
+    process.env.MEDIA_BUCKET_NAME ||
+    process.env.S3_MEDIA_BUCKET_NAME ||
+    'torus-media-dev'
+  );
+}
+
+export function defaultLocalMinioMediaUrlPrefix(): string {
+  const explicitPrefix = process.env.MINIO_MEDIA_URL_PREFIX;
+  if (explicitPrefix) {
+    return explicitPrefix.trim().replace(/\/+$/, '');
+  }
+
+  const endpoint =
+    process.env.MINIO_PUBLIC_URL ||
+    process.env.MINIO_ENDPOINT ||
+    `http://localhost:${process.env.AWS_S3_PORT || '9000'}`;
+
+  return `${endpoint.replace(/\/+$/, '')}/${localMinioBucketName()}/media`;
+}
+
 function validateArgs(options: CmdOptions) {
   if (options.operation === 'convert' || options.operation === 'qti') {
     if (options.mediaUrlPrefix === undefined) {
-      options.mediaUrlPrefix = 'https://d2xvti2irp4c7t.cloudfront.net/media';
+      options.mediaUrlPrefix = options.localMinio
+        ? defaultLocalMinioMediaUrlPrefix()
+        : 'https://d2xvti2irp4c7t.cloudfront.net/media';
     } else {
       // remove any trailing slashes from the media URL prefix
       options.mediaUrlPrefix = options.mediaUrlPrefix
@@ -190,17 +217,16 @@ function readMediaManifest(options: CmdOptions): Media.MediaManifest {
   return JSON.parse(raw.toString());
 }
 
-function uploadMediaItems(items: Media.ProcessedMediaItem[]) {
-  const bucketName = Maybe.maybe(process.env.MEDIA_BUCKET_NAME).valueOrThrow(
-    Error('MEDIA_BUCKET_NAME not set in config')
-  );
-
+function uploadMediaItems(
+  items: Media.ProcessedMediaItem[],
+  options: CmdOptions
+) {
   const uploaders = items.map((m: Media.MediaItem) => {
     return () => {
       console.log(`Uploading ${m.file}...`);
-      return upload(m.file, m.url, m.mimeType, bucketName).then((location) =>
-        console.log(`${location} complete`)
-      );
+      return upload(m.file, m.url, m.mimeType, {
+        localMinio: options.localMinio,
+      }).then((location) => console.log(`${location} complete`));
     };
   });
 
@@ -213,7 +239,7 @@ export function uploadAction(options: CmdOptions) {
     ? manifest.webContentBundle.items
     : [];
 
-  return uploadMediaItems(manifest.mediaItems.concat(bundleItems));
+  return uploadMediaItems(manifest.mediaItems.concat(bundleItems), options);
 }
 
 export function convertAction(options: CmdOptions): Promise<ConvertedResults> {
@@ -388,7 +414,7 @@ function suggestUploadAction(options: CmdOptions) {
   })
     .then((answer: string) => {
       if (anyOf(answer || 'n', 'y', 'yes')) {
-        return uploadMediaItems(manifest.mediaItems).then((_r: any) =>
+        return uploadMediaItems(manifest.mediaItems, options).then((_r: any) =>
           console.log('Done!')
         );
       }
@@ -418,9 +444,10 @@ function suggestUploadAction(options: CmdOptions) {
     .then((answer: string) => {
       if (manifest.webContentBundle) {
         if (anyOf(answer || 'n', 'y', 'yes')) {
-          return uploadMediaItems(manifest.webContentBundle.items).then(
-            (_r: any) => console.log('Done!')
-          );
+          return uploadMediaItems(
+            manifest.webContentBundle.items,
+            options
+          ).then((_r: any) => console.log('Done!'));
         }
 
         console.log('Skipping media bundle upload.');
@@ -538,6 +565,10 @@ function helpAction() {
   console.log(
     'npm run start -- upload --mediaManifest <outputDir/_media-manifest.json>'
   );
+  console.log(
+    'npm run start -- upload --mediaManifest <outputDir/_media-manifest.json> --localMinio'
+  );
+  console.log('\nFor local MinIO, configure MINIO_* values in .env.');
   console.log(
     'npm run start -- summarize --inputDir <course package dir> --outputDir <output dir>\n'
   );

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -1,36 +1,112 @@
 import * as AWS from 'aws-sdk';
 import * as fs from 'fs';
 
+export interface UploadOptions {
+  bucketName?: string;
+  localMinio?: boolean;
+}
+
+export interface ResolvedUploadConfig {
+  bucketName: string;
+  localMinio: boolean;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  endpoint?: string;
+}
+
+export function s3KeyFromUrl(url: string, bucketName: string): string {
+  const { pathname } = new URL(url);
+
+  const normalizedPath = pathname.replace(/^\/+/, '');
+  const bucketPrefix = [`buckets/${bucketName}/`, `${bucketName}/`].find(
+    (prefix) => normalizedPath.startsWith(prefix)
+  );
+  const pathWithoutBucketPrefix = bucketPrefix
+    ? normalizedPath.slice(bucketPrefix.length)
+    : normalizedPath;
+
+  return decodeURIComponent(pathWithoutBucketPrefix);
+}
+
+export function resolveUploadConfig(
+  options: UploadOptions = {}
+): ResolvedUploadConfig {
+  const localMinio = options.localMinio === true;
+  const bucketName = localMinio
+    ? options.bucketName ||
+      process.env.MINIO_BUCKET_NAME ||
+      process.env.MINIO_MEDIA_BUCKET_NAME ||
+      'torus-media-dev'
+    : options.bucketName ||
+      process.env.MEDIA_BUCKET_NAME ||
+      process.env.S3_MEDIA_BUCKET_NAME;
+
+  if (bucketName === undefined) {
+    throw Error('MEDIA_BUCKET_NAME not set in config');
+  }
+
+  const accessKeyId = localMinio
+    ? process.env.MINIO_ROOT_USER
+    : process.env.AWS_S3_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = localMinio
+    ? process.env.MINIO_ROOT_PASSWORD
+    : process.env.AWS_S3_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY;
+
+  if (localMinio && (!accessKeyId || !secretAccessKey)) {
+    throw Error(
+      'Missing MinIO credentials. Set MINIO_ROOT_USER and MINIO_ROOT_PASSWORD in .env.'
+    );
+  }
+
+  return {
+    bucketName,
+    localMinio,
+    accessKeyId,
+    secretAccessKey,
+    endpoint: localMinio
+      ? process.env.MINIO_ENDPOINT ||
+        process.env.AWS_ENDPOINT_URL ||
+        `http://localhost:${process.env.AWS_S3_PORT || '9000'}`
+      : undefined,
+  };
+}
+
 export const upload = (
   file: string,
   url: string,
   mimeType: string,
-  bucketName: string
+  options: UploadOptions = {}
 ) => {
   // Read content from the file
   const fileContent = fs.readFileSync(file);
-
-  // Get the s3 path after host in URL of form https://host.com/foo/bar
-  const s3Path = url.split('/').slice(3).join('/');
+  const config = resolveUploadConfig(options);
 
   // S3 keys are officially just arbitrary strings of UTF-8 characters. URLs that come here have been
   // URL encoded, but must pass NON-URL-encoded s3 Key to AWS API to avoid mismatch with expected url.
   // Otherwise, e.g. if file "foo bar.jpg" uploaded w/key "foo%20bar.jpg" it would require URL
   // https://.../foo%2520bar.jpg to access.
-  const s3PathKey = decodeURIComponent(s3Path);
+  const s3PathKey = s3KeyFromUrl(url, config.bucketName);
 
   // Setting up S3 upload parameters
   const params: AWS.S3.PutObjectRequest = {
-    Bucket: bucketName,
+    Bucket: config.bucketName,
     Key: s3PathKey,
     Body: fileContent,
     ContentType: mimeType,
   };
 
-  const s3 = new AWS.S3({
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  });
+  const s3Config: AWS.S3.ClientConfiguration = {
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+  };
+
+  if (config.localMinio && config.endpoint) {
+    s3Config.endpoint = new AWS.Endpoint(config.endpoint);
+    s3Config.s3ForcePathStyle = true;
+    s3Config.signatureVersion = 'v4';
+  }
+
+  const s3 = new AWS.S3(s3Config);
 
   // Uploading files to the bucket
   return new Promise((resolve, reject) => {

--- a/test/index-minio-test.ts
+++ b/test/index-minio-test.ts
@@ -1,0 +1,43 @@
+import {
+  defaultLocalMinioMediaUrlPrefix,
+  localMinioBucketName,
+} from 'src/index';
+
+const originalEnv = process.env;
+
+describe('index MinIO defaults', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.MINIO_BUCKET_NAME;
+    delete process.env.MINIO_MEDIA_BUCKET_NAME;
+    delete process.env.MEDIA_BUCKET_NAME;
+    delete process.env.S3_MEDIA_BUCKET_NAME;
+    delete process.env.MINIO_MEDIA_URL_PREFIX;
+    delete process.env.MINIO_PUBLIC_URL;
+    delete process.env.MINIO_ENDPOINT;
+    delete process.env.AWS_S3_PORT;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should prefer explicit MinIO media url prefix from .env', () => {
+    process.env.MINIO_MEDIA_URL_PREFIX =
+      'http://localhost/buckets/torus-media-dev/media/';
+
+    expect(defaultLocalMinioMediaUrlPrefix()).toBe(
+      'http://localhost/buckets/torus-media-dev/media'
+    );
+  });
+
+  it('should derive MinIO media url prefix from endpoint and bucket', () => {
+    process.env.MINIO_ENDPOINT = 'http://localhost:9000/';
+    process.env.MINIO_BUCKET_NAME = 'torus-media-dev';
+
+    expect(localMinioBucketName()).toBe('torus-media-dev');
+    expect(defaultLocalMinioMediaUrlPrefix()).toBe(
+      'http://localhost:9000/torus-media-dev/media'
+    );
+  });
+});

--- a/test/utils/upload-test.ts
+++ b/test/utils/upload-test.ts
@@ -1,0 +1,117 @@
+const mockUpload = jest.fn();
+const mockS3 = jest.fn().mockImplementation(() => ({
+  upload: mockUpload,
+}));
+const mockEndpoint = jest
+  .fn()
+  .mockImplementation((value: string) => ({ value }));
+
+jest.mock('aws-sdk', () => ({
+  S3: mockS3,
+  Endpoint: mockEndpoint,
+}));
+
+import * as fs from 'fs';
+import { resolveUploadConfig, s3KeyFromUrl, upload } from 'src/utils/upload';
+
+const originalEnv = process.env;
+
+describe('upload utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should strip bucket prefixes from local MinIO URLs', () => {
+    expect(
+      s3KeyFromUrl(
+        'http://localhost/buckets/torus-media-dev/media/foo%20bar.jpg',
+        'torus-media-dev'
+      )
+    ).toBe('media/foo bar.jpg');
+
+    expect(
+      s3KeyFromUrl(
+        'http://localhost/torus-media-dev/media/foo%20bar.jpg',
+        'torus-media-dev'
+      )
+    ).toBe('media/foo bar.jpg');
+  });
+
+  it('should keep normal S3 object paths unchanged', () => {
+    expect(
+      s3KeyFromUrl(
+        'https://torus-media-dev.s3.amazonaws.com/media/foo%20bar.jpg',
+        'torus-media-dev'
+      )
+    ).toBe('media/foo bar.jpg');
+  });
+
+  it('should resolve MinIO defaults for local development', () => {
+    process.env.MINIO_ROOT_USER = 'minio-user';
+    process.env.MINIO_ROOT_PASSWORD = 'minio-password';
+    process.env.MINIO_BUCKET_NAME = 'minio-media-dev';
+    process.env.AWS_S3_PORT = '9000';
+
+    expect(resolveUploadConfig({ localMinio: true })).toEqual({
+      bucketName: 'minio-media-dev',
+      localMinio: true,
+      accessKeyId: 'minio-user',
+      secretAccessKey: 'minio-password',
+      endpoint: 'http://localhost:9000',
+    });
+  });
+
+  it('should ignore AWS credentials when local MinIO is enabled', () => {
+    process.env.AWS_ACCESS_KEY_ID = 'aws-user';
+    process.env.AWS_SECRET_ACCESS_KEY = 'aws-password';
+
+    expect(() => resolveUploadConfig({ localMinio: true })).toThrow(
+      'Missing MinIO credentials. Set MINIO_ROOT_USER and MINIO_ROOT_PASSWORD in .env.'
+    );
+  });
+
+  it('should upload to MinIO using path-style S3 config', async () => {
+    process.env.MINIO_ROOT_USER = 'minio-user';
+    process.env.MINIO_ROOT_PASSWORD = 'minio-password';
+
+    jest
+      .spyOn(fs, 'readFileSync')
+      .mockReturnValue(Buffer.from('file-content') as any);
+    mockUpload.mockImplementation(
+      (_params: unknown, callback: (err: any, data?: any) => void) =>
+        callback(undefined, { Location: 'http://localhost/uploaded' })
+    );
+
+    await expect(
+      upload(
+        '/tmp/example.jpg',
+        'http://localhost/buckets/torus-media-dev/media/example%20file.jpg',
+        'image/jpeg',
+        { localMinio: true }
+      )
+    ).resolves.toBe('http://localhost/uploaded');
+
+    expect(mockEndpoint).toHaveBeenCalledWith('http://localhost:9000');
+    expect(mockS3).toHaveBeenCalledWith({
+      accessKeyId: 'minio-user',
+      secretAccessKey: 'minio-password',
+      endpoint: { value: 'http://localhost:9000' },
+      s3ForcePathStyle: true,
+      signatureVersion: 'v4',
+    });
+    expect(mockUpload).toHaveBeenCalledWith(
+      {
+        Bucket: 'torus-media-dev',
+        Key: 'media/example file.jpg',
+        Body: Buffer.from('file-content'),
+        ContentType: 'image/jpeg',
+      },
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
## Summary

  This PR adds local MinIO support to `course-digest` so media uploads can target a local S3-compatible store
  during development.

  ### What changed

  - Added a `--localMinio` CLI option for upload flows.
  - Added MinIO-specific environment handling for local development:
    - `MINIO_ROOT_USER`
    - `MINIO_ROOT_PASSWORD`
    - `MINIO_BUCKET_NAME`
    - `MINIO_ENDPOINT`
    - `MINIO_MEDIA_URL_PREFIX`
  - Updated local MinIO mode to use MinIO-specific variables instead of falling back to AWS credentials.
  - Added default local media URL prefix derivation when `--localMinio` is enabled and `MINIO_MEDIA_URL_PREFIX`
  is not set.
  - Added support for stripping bucket-prefixed local MinIO URLs when deriving object keys for upload.
  - Added `.env.example` entries documenting the new MinIO configuration.
  - Updated the README with local MinIO setup and usage instructions.

  ## Implementation details

  - [src/index.ts](src/index.ts)
    - added `--localMinio`
    - added helpers to derive the local MinIO bucket name and media URL prefix from env
    - routed upload actions through MinIO-aware config when the flag is enabled

  - [src/utils/upload.ts](src/utils/upload.ts)
    - added MinIO-aware upload config resolution
    - configured path-style S3 access for MinIO
    - ensured local MinIO uploads use MinIO env vars only
    - normalized object key extraction for local bucket-prefixed URLs

  - [.env.example](.env.example)
    - added MinIO example variables for local development

  - [README.md](README.md)
    - documented `.env`-based local MinIO setup and usage

  ## Tests

  Added coverage for:
  - local MinIO URL key extraction
  - MinIO default config resolution
  - MinIO upload client configuration
  - local media URL prefix derivation from env
  - ensuring local MinIO mode ignores AWS credentials